### PR TITLE
Emit CommonJS instead of ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "description": "Lightweight TypeScript-first Vue prop type definitions",
   "main": "dist/index.js",
-  "type": "module",
   "types": "dist/index.d.ts",
   "scripts": {
     "test": "jest",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,7 @@
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
 
     /* Modules */
-    "module": "es2020",                                  /* Specify what module code is generated. */
+    "module": "commonjs",                                  /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     "moduleResolution": "node",                          /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */


### PR DESCRIPTION
To enable use in `vue-server-renderer`, which runs on Node and directly `require`s imported modules without transpilation.