### PR TITLE
Make PropOptions interface public to fix TypeScript error

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-interface PropOptions<T> {
+export interface PropOptions<T> {
   type?: PropType<T>;
   required?: boolean;
   default?: T | (() => T | null | undefined) | null | undefined;


### PR DESCRIPTION
```ts
import { functionProp } from 'vue-ts-types'

export type SaveFunction = (product: Product | Product[]) => void

export default defineComponent({
  name: 'Foo',
  props: {
    saveFunction: functionProp<SaveFunction>().required,
  },
})
```

throws TypeScript error:

```
Default export of the module has or is using private name 'PropOptions'.
```