### PR TITLE
Ensure compatibility with multiple versions of Vue

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -30,7 +30,9 @@ module.exports = {
     'arrow-spacing': 'error',
     'block-spacing': 'error',
     'brace-style': ['error', 'stroustrup'],
-    'camelcase': 'error',
+    'camelcase': ['error', {
+      allow: ['Vue2_6', 'Vue2_7'],
+    }],
     'comma-dangle': ['error', 'always-multiline'],
     'comma-spacing': 'error',
     'comma-style': 'error',

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Vue.component('MyComponent', {
 npm install vue-ts-types
 ```
 
+`vue-ts-types` is tested to be compatible with [Vue.js](https://vuejs.org/) `v2.6`, `v2.7` and `v3.2`.
+
 ## Usage
 
 Each of the prop functions returns an object with the following properties:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1513,10 +1513,113 @@
         "eslint-visitor-keys": "^3.3.0"
       }
     },
-    "@vue/composition-api": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@vue/composition-api/-/composition-api-1.7.0.tgz",
-      "integrity": "sha512-hxOgLYR+wjuPX9bkP2pAPlqUs98XxBoa9DSLyp1z6+YR92wC42PZcZKs4d+VRtcv4udOv041Kss+F6ap5nj8YA==",
+    "@vue/compiler-core": {
+      "version": "3.2.37",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.37.tgz",
+      "integrity": "sha512-81KhEjo7YAOh0vQJoSmAD68wLfYqJvoiD4ulyedzF+OEk/bk6/hx3fTNVfuzugIIaTrOx4PGx6pAiBRe5e9Zmg==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.16.4",
+        "@vue/shared": "3.2.37",
+        "estree-walker": "^2.0.2",
+        "source-map": "^0.6.1"
+      }
+    },
+    "@vue/compiler-dom": {
+      "version": "3.2.37",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.37.tgz",
+      "integrity": "sha512-yxJLH167fucHKxaqXpYk7x8z7mMEnXOw3G2q62FTkmsvNxu4FQSu5+3UMb+L7fjKa26DEzhrmCxAgFLLIzVfqQ==",
+      "dev": true,
+      "requires": {
+        "@vue/compiler-core": "3.2.37",
+        "@vue/shared": "3.2.37"
+      }
+    },
+    "@vue/compiler-sfc": {
+      "version": "3.2.37",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.37.tgz",
+      "integrity": "sha512-+7i/2+9LYlpqDv+KTtWhOZH+pa8/HnX/905MdVmAcI/mPQOBwkHHIzrsEsucyOIZQYMkXUiTkmZq5am/NyXKkg==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.16.4",
+        "@vue/compiler-core": "3.2.37",
+        "@vue/compiler-dom": "3.2.37",
+        "@vue/compiler-ssr": "3.2.37",
+        "@vue/reactivity-transform": "3.2.37",
+        "@vue/shared": "3.2.37",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.25.7",
+        "postcss": "^8.1.10",
+        "source-map": "^0.6.1"
+      }
+    },
+    "@vue/compiler-ssr": {
+      "version": "3.2.37",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.37.tgz",
+      "integrity": "sha512-7mQJD7HdXxQjktmsWp/J67lThEIcxLemz1Vb5I6rYJHR5vI+lON3nPGOH3ubmbvYGt8xEUaAr1j7/tIFWiEOqw==",
+      "dev": true,
+      "requires": {
+        "@vue/compiler-dom": "3.2.37",
+        "@vue/shared": "3.2.37"
+      }
+    },
+    "@vue/reactivity": {
+      "version": "3.2.37",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.37.tgz",
+      "integrity": "sha512-/7WRafBOshOc6m3F7plwzPeCu/RCVv9uMpOwa/5PiY1Zz+WLVRWiy0MYKwmg19KBdGtFWsmZ4cD+LOdVPcs52A==",
+      "dev": true,
+      "requires": {
+        "@vue/shared": "3.2.37"
+      }
+    },
+    "@vue/reactivity-transform": {
+      "version": "3.2.37",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.37.tgz",
+      "integrity": "sha512-IWopkKEb+8qpu/1eMKVeXrK0NLw9HicGviJzhJDEyfxTR9e1WtpnnbYkJWurX6WwoFP0sz10xQg8yL8lgskAZg==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.16.4",
+        "@vue/compiler-core": "3.2.37",
+        "@vue/shared": "3.2.37",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.25.7"
+      }
+    },
+    "@vue/runtime-core": {
+      "version": "3.2.37",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.37.tgz",
+      "integrity": "sha512-JPcd9kFyEdXLl/i0ClS7lwgcs0QpUAWj+SKX2ZC3ANKi1U4DOtiEr6cRqFXsPwY5u1L9fAjkinIdB8Rz3FoYNQ==",
+      "dev": true,
+      "requires": {
+        "@vue/reactivity": "3.2.37",
+        "@vue/shared": "3.2.37"
+      }
+    },
+    "@vue/runtime-dom": {
+      "version": "3.2.37",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.37.tgz",
+      "integrity": "sha512-HimKdh9BepShW6YozwRKAYjYQWg9mQn63RGEiSswMbW+ssIht1MILYlVGkAGGQbkhSh31PCdoUcfiu4apXJoPw==",
+      "dev": true,
+      "requires": {
+        "@vue/runtime-core": "3.2.37",
+        "@vue/shared": "3.2.37",
+        "csstype": "^2.6.8"
+      }
+    },
+    "@vue/server-renderer": {
+      "version": "3.2.37",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.37.tgz",
+      "integrity": "sha512-kLITEJvaYgZQ2h47hIzPh2K3jG8c1zCVbp/o/bzQOyvzaKiCquKS7AaioPI28GNxIsE/zSx+EwWYsNxDCX95MA==",
+      "dev": true,
+      "requires": {
+        "@vue/compiler-ssr": "3.2.37",
+        "@vue/shared": "3.2.37"
+      }
+    },
+    "@vue/shared": {
+      "version": "3.2.37",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.37.tgz",
+      "integrity": "sha512-4rSJemR2NQIo9Klm1vabqWjD8rs/ZaJSzMxkMNeJS6lHiUjjUeYFbooN19NgFjztubEKh3WlZUeOLVdbbUWHsw==",
       "dev": true
     },
     "acorn": {
@@ -1790,7 +1893,7 @@
     "clean-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
-      "integrity": "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==",
+      "integrity": "sha1-jffHquUf02h06PjQW5GAvBGj/tc=",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
@@ -1810,7 +1913,7 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
     "collect-v8-coverage": {
@@ -1877,6 +1980,12 @@
         "which": "^2.0.1"
       }
     },
+    "csstype": {
+      "version": "2.6.20",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
+      "integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==",
+      "dev": true
+    },
     "debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -1889,7 +1998,7 @@
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-      "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
     },
     "deep-is": {
@@ -2229,6 +2338,12 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
+    "estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2255,7 +2370,7 @@
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
     "expect": {
@@ -2299,7 +2414,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "fastq": {
@@ -3267,7 +3382,7 @@
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
     "json5": {
@@ -3322,7 +3437,7 @@
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
     "lodash.merge": {
@@ -3338,6 +3453,15 @@
       "dev": true,
       "requires": {
         "yallist": "^4.0.0"
+      }
+    },
+    "magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.8"
       }
     },
     "make-dir": {
@@ -3413,6 +3537,12 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "dev": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3422,7 +3552,7 @@
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true
     },
     "node-releases": {
@@ -3606,6 +3736,17 @@
       "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
       "dev": true
     },
+    "postcss": {
+      "version": "8.4.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+      "dev": true,
+      "requires": {
+        "nanoid": "^3.3.4",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      }
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3714,7 +3855,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "resolve": {
@@ -3833,6 +3974,12 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
     },
+    "source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true
+    },
     "source-map-support": {
       "version": "0.5.13",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
@@ -3842,6 +3989,12 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
     },
     "spdx-correct": {
       "version": "3.1.1",
@@ -3878,7 +4031,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "stack-utils": {
@@ -4004,7 +4157,7 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "throat": {
@@ -4022,7 +4175,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
     "to-regex-range": {
@@ -4183,10 +4336,52 @@
       }
     },
     "vue": {
-      "version": "2.6.14",
+      "version": "3.2.37",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.37.tgz",
+      "integrity": "sha512-bOKEZxrm8Eh+fveCqS1/NkG/n6aMidsI6hahas7pa0w/l7jkbssJVsRhVDs07IdDq7h9KHswZOgItnwJAgtVtQ==",
+      "dev": true,
+      "requires": {
+        "@vue/compiler-dom": "3.2.37",
+        "@vue/compiler-sfc": "3.2.37",
+        "@vue/runtime-dom": "3.2.37",
+        "@vue/server-renderer": "3.2.37",
+        "@vue/shared": "3.2.37"
+      }
+    },
+    "vue2-6": {
+      "version": "npm:vue@2.6.14",
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
       "integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ==",
       "dev": true
+    },
+    "vue2-7": {
+      "version": "npm:vue@2.7.5",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.5.tgz",
+      "integrity": "sha512-mUDXXgBIFr9dk0k/3dpB6wtnCxRhe9mbGxWLtha9mTUrEWkdkZW1d58vl98VKWH067NA8f1Wj4Qwq7y7DDYfyw==",
+      "dev": true,
+      "requires": {
+        "@vue/compiler-sfc": "2.7.5",
+        "csstype": "^3.1.0"
+      },
+      "dependencies": {
+        "@vue/compiler-sfc": {
+          "version": "2.7.5",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.5.tgz",
+          "integrity": "sha512-f2xlkMzBLbTAUy13N4aJBnmb7+86WJqoGqHDibkGHd1/CabpNVvzhpBFlfWJjBrGWIcWywNGgGSuoWzpCUuD4w==",
+          "dev": true,
+          "requires": {
+            "@babel/parser": "^7.18.4",
+            "postcss": "^8.4.14",
+            "source-map": "^0.6.1"
+          }
+        },
+        "csstype": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
+          "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==",
+          "dev": true
+        }
+      }
     },
     "walker": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@types/jest": "^28.1.5",
     "@typescript-eslint/eslint-plugin": "^5.30.6",
     "@typescript-eslint/parser": "^5.30.6",
-    "@vue/composition-api": "^1.7.0",
     "eslint": "^8.19.0",
     "eslint-plugin-jest": "^26.5.3",
     "eslint-plugin-unicorn": "^43.0.1",
@@ -49,7 +48,9 @@
     "ts-jest": "^28.0.5",
     "ts-node": "^10.8.2",
     "typescript": "^4.7.4",
-    "vue": "^2.6.14"
+    "vue": "^3.2.37",
+    "vue2-6": "npm:vue@~2.6.14",
+    "vue2-7": "npm:vue@~2.7.5"
   },
   "peerDependencies": {
     "vue": "^2.6 || ^3.2"

--- a/src/prop-types/function.ts
+++ b/src/prop-types/function.ts
@@ -18,13 +18,13 @@ interface FunctionPropOptionsGenerator<T> {
  */
 export const functionProp = <T extends Function>(validator?: Validator): FunctionPropOptionsGenerator<T> => ({
   optional: {
-    type: Function,
+    type: Function as unknown as () => T,
     required: false,
     default: undefined,
     validator: vuePropValidator(validator),
   },
   required: {
-    type: Function,
+    type: Function as unknown as () => T,
     required: true,
     validator: vuePropValidator(validator),
   },

--- a/src/prop-types/vueComponent.ts
+++ b/src/prop-types/vueComponent.ts
@@ -1,9 +1,9 @@
-import type { ComponentOptions, VueConstructor } from 'vue2-6';
 import type { PropOptionsGenerator } from '../types';
 import { propOptionsGenerator } from '../util';
 import type { Validator } from '../validators';
 
-export type VueComponent = ComponentOptions<Vue> | VueConstructor<Vue> | string
+/** Has to be so broad to allow Vue 2 and Vue 3 component options or instances. */
+export type VueComponent = object | string
 
 /**
  * Allows any Vue component instance, name or options object. No built-in runtime validation is performed by default.

--- a/src/prop-types/vueComponent.ts
+++ b/src/prop-types/vueComponent.ts
@@ -1,4 +1,4 @@
-import type { ComponentOptions, VueConstructor } from 'vue';
+import type { ComponentOptions, VueConstructor } from 'vue2-6';
 import type { PropOptionsGenerator } from '../types';
 import { propOptionsGenerator } from '../util';
 import type { Validator } from '../validators';

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,8 +12,6 @@ export type PropConstructor<T> =
   | { (): T }
   // eslint-disable-next-line @typescript-eslint/prefer-function-type
   | { new(...parameters: any[]): T & object }
-  // eslint-disable-next-line @typescript-eslint/ban-types, @typescript-eslint/prefer-function-type
-  | { new(...parameters: string[]): Function }
 
 
 export type RequiredPropOptions<T> = PropOptions<T> & { required: true }

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -14,7 +14,14 @@ export function vuePropValidator(userValidator?: Validator, ...typeValidators: V
     for (const validator of validators) {
       const errorMessage = validator(value);
       if (errorMessage) {
-        Vue.util.warn(`${errorMessage} (received: '${String(value)}')`);
+        if (typeof Vue === 'object' && 'util' in Vue) {
+          // @ts-expect-error -- Vue.util is only available in Vue 2, but provides more context than console.warn
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+          Vue.util.warn(`${errorMessage} (received: '${String(value)}')`);
+        }
+        else {
+          console.warn(`${errorMessage} (received: '${String(value)}')`);
+        }
         return false;
       }
     }

--- a/tests/validators.spec.ts
+++ b/tests/validators.spec.ts
@@ -1,4 +1,3 @@
-import Vue from 'vue2-6';
 import { isInstanceOf, isInteger, isOneOf, isSymbol, vuePropValidator } from '../src/validators';
 
 describe('vuePropValidator', () => {
@@ -7,7 +6,7 @@ describe('vuePropValidator', () => {
   const validator3 = jest.fn().mockReturnValue('some error message');
   const validator4 = jest.fn();
 
-  const warnSpy = jest.spyOn(Vue.util, 'warn').mockImplementation();
+  const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
 
   it('returns undefined if no validator is passed', () => {
     expect(vuePropValidator()).toBeUndefined();

--- a/tests/validators.spec.ts
+++ b/tests/validators.spec.ts
@@ -1,4 +1,4 @@
-import Vue from 'vue';
+import Vue from 'vue2-6';
 import { isInstanceOf, isInteger, isOneOf, isSymbol, vuePropValidator } from '../src/validators';
 
 describe('vuePropValidator', () => {

--- a/type-tests/prop-types/any.type.spec.ts
+++ b/type-tests/prop-types/any.type.spec.ts
@@ -1,17 +1,17 @@
 import { expectAssignable, expectNotAssignable, expectType } from 'tsd-lite';
-import type * as Vue2 from 'vue/types/options';
-import type * as CompositionApi from '@vue/composition-api';
+import type * as Vue2_6 from 'vue2-6/types/options';
+import type * as Vue2_7 from 'vue2-7/types/options';
 import { anyProp } from '../../src/prop-types/any';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';
 
 describe('anyProp().optional', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions>(anyProp().optional);
-    expectAssignable<Vue2.PropOptions<number>>(anyProp().optional);
-    expectAssignable<Vue2.PropOptions<string>>(anyProp().optional);
-    expectAssignable<Vue2.PropOptions<string | undefined>>(anyProp<string>().optional);
-    expectNotAssignable<Vue2.PropOptions<string>>(anyProp<string>().optional);
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions>(anyProp().optional);
+    expectAssignable<Vue2_6.PropOptions<number>>(anyProp().optional);
+    expectAssignable<Vue2_6.PropOptions<string>>(anyProp().optional);
+    expectAssignable<Vue2_6.PropOptions<string | undefined>>(anyProp<string>().optional);
+    expectNotAssignable<Vue2_6.PropOptions<string>>(anyProp<string>().optional);
 
     expectType<Vue2ComponentWithProp<any>>(
       createVue2Component(anyProp().optional),
@@ -22,22 +22,22 @@ describe('anyProp().optional', () => {
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions>(anyProp().optional);
-    expectAssignable<CompositionApi.PropOptions<number>>(anyProp().optional);
-    expectAssignable<CompositionApi.PropOptions<string>>(anyProp().optional);
-    expectAssignable<CompositionApi.PropOptions<string | undefined>>(anyProp<string>().optional);
-    expectNotAssignable<CompositionApi.PropOptions<string>>(anyProp<string>().optional);
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions>(anyProp().optional);
+    expectAssignable<Vue2_7.PropOptions<number>>(anyProp().optional);
+    expectAssignable<Vue2_7.PropOptions<string>>(anyProp().optional);
+    expectAssignable<Vue2_7.PropOptions<string | undefined>>(anyProp<string>().optional);
+    expectNotAssignable<Vue2_7.PropOptions<string>>(anyProp<string>().optional);
   });
 });
 
 describe('anyProp().withDefault', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions>(anyProp().withDefault('foo'));
-    expectAssignable<Vue2.PropOptions<string>>(anyProp().withDefault('foo'));
-    expectAssignable<Vue2.PropOptions<number>>(anyProp().withDefault('foo'));
-    expectAssignable<Vue2.PropOptions<string>>(anyProp<string>().withDefault('foo'));
-    expectNotAssignable<Vue2.PropOptions<number>>(anyProp<string>().withDefault('foo'));
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions>(anyProp().withDefault('foo'));
+    expectAssignable<Vue2_6.PropOptions<string>>(anyProp().withDefault('foo'));
+    expectAssignable<Vue2_6.PropOptions<number>>(anyProp().withDefault('foo'));
+    expectAssignable<Vue2_6.PropOptions<string>>(anyProp<string>().withDefault('foo'));
+    expectNotAssignable<Vue2_6.PropOptions<number>>(anyProp<string>().withDefault('foo'));
 
     expectType<Vue2ComponentWithProp<any>>(
       createVue2Component(anyProp().withDefault('foo')),
@@ -48,21 +48,21 @@ describe('anyProp().withDefault', () => {
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions>(anyProp().withDefault('foo'));
-    expectAssignable<CompositionApi.PropOptions<string>>(anyProp().withDefault('foo'));
-    expectAssignable<CompositionApi.PropOptions<number>>(anyProp().withDefault('foo'));
-    expectAssignable<CompositionApi.PropOptions<string>>(anyProp<string>().withDefault('foo'));
-    expectNotAssignable<CompositionApi.PropOptions<number>>(anyProp<string>().withDefault('foo'));
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions>(anyProp().withDefault('foo'));
+    expectAssignable<Vue2_7.PropOptions<string>>(anyProp().withDefault('foo'));
+    expectAssignable<Vue2_7.PropOptions<number>>(anyProp().withDefault('foo'));
+    expectAssignable<Vue2_7.PropOptions<string>>(anyProp<string>().withDefault('foo'));
+    expectNotAssignable<Vue2_7.PropOptions<number>>(anyProp<string>().withDefault('foo'));
   });
 });
 
 describe('anyProp().required', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions>(anyProp().required);
-    expectAssignable<Vue2.PropOptions<string>>(anyProp().required);
-    expectAssignable<Vue2.PropOptions<string>>(anyProp<string>().required);
-    expectNotAssignable<Vue2.PropOptions<number>>(anyProp<string>().required);
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions>(anyProp().required);
+    expectAssignable<Vue2_6.PropOptions<string>>(anyProp().required);
+    expectAssignable<Vue2_6.PropOptions<string>>(anyProp<string>().required);
+    expectNotAssignable<Vue2_6.PropOptions<number>>(anyProp<string>().required);
 
     expectType<Vue2ComponentWithProp<any>>(
       createVue2Component(anyProp().required),
@@ -73,10 +73,10 @@ describe('anyProp().required', () => {
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions>(anyProp().required);
-    expectAssignable<CompositionApi.PropOptions<string>>(anyProp().required);
-    expectAssignable<CompositionApi.PropOptions<string>>(anyProp<string>().required);
-    expectNotAssignable<CompositionApi.PropOptions<number>>(anyProp<string>().required);
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions>(anyProp().required);
+    expectAssignable<Vue2_7.PropOptions<string>>(anyProp().required);
+    expectAssignable<Vue2_7.PropOptions<string>>(anyProp<string>().required);
+    expectNotAssignable<Vue2_7.PropOptions<number>>(anyProp<string>().required);
   });
 });

--- a/type-tests/prop-types/any.type.spec.ts
+++ b/type-tests/prop-types/any.type.spec.ts
@@ -1,6 +1,7 @@
 import { expectAssignable, expectNotAssignable, expectType } from 'tsd-lite';
 import type * as Vue2_6 from 'vue2-6/types/options';
 import type * as Vue2_7 from 'vue2-7/types/options';
+import type * as Vue3 from '@vue/runtime-core/dist/runtime-core';
 import { anyProp } from '../../src/prop-types/any';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';
@@ -29,6 +30,14 @@ describe('anyProp().optional', () => {
     expectAssignable<Vue2_7.PropOptions<string | undefined>>(anyProp<string>().optional);
     expectNotAssignable<Vue2_7.PropOptions<string>>(anyProp<string>().optional);
   });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<any>>(anyProp().optional);
+    expectAssignable<Vue3.Prop<number>>(anyProp().optional);
+    expectAssignable<Vue3.Prop<string>>(anyProp().optional);
+    expectAssignable<Vue3.Prop<string | undefined>>(anyProp<string>().optional);
+    expectNotAssignable<Vue3.Prop<string>>(anyProp<string>().optional);
+  });
 });
 
 describe('anyProp().withDefault', () => {
@@ -55,6 +64,14 @@ describe('anyProp().withDefault', () => {
     expectAssignable<Vue2_7.PropOptions<string>>(anyProp<string>().withDefault('foo'));
     expectNotAssignable<Vue2_7.PropOptions<number>>(anyProp<string>().withDefault('foo'));
   });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<any>>(anyProp().withDefault('foo'));
+    expectAssignable<Vue3.Prop<string>>(anyProp().withDefault('foo'));
+    expectAssignable<Vue3.Prop<number>>(anyProp().withDefault('foo'));
+    expectAssignable<Vue3.Prop<string>>(anyProp<string>().withDefault('foo'));
+    expectNotAssignable<Vue3.Prop<number>>(anyProp<string>().withDefault('foo'));
+  });
 });
 
 describe('anyProp().required', () => {
@@ -78,5 +95,12 @@ describe('anyProp().required', () => {
     expectAssignable<Vue2_7.PropOptions<string>>(anyProp().required);
     expectAssignable<Vue2_7.PropOptions<string>>(anyProp<string>().required);
     expectNotAssignable<Vue2_7.PropOptions<number>>(anyProp<string>().required);
+  });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<any>>(anyProp().required);
+    expectAssignable<Vue3.Prop<string>>(anyProp().required);
+    expectAssignable<Vue3.Prop<string>>(anyProp<string>().required);
+    expectNotAssignable<Vue3.Prop<number>>(anyProp<string>().required);
   });
 });

--- a/type-tests/prop-types/array.type.spec.ts
+++ b/type-tests/prop-types/array.type.spec.ts
@@ -1,6 +1,7 @@
 import { expectAssignable, expectNotAssignable, expectType } from 'tsd-lite';
 import type * as Vue2_6 from 'vue2-6/types/options';
 import type * as Vue2_7 from 'vue2-7/types/options';
+import type * as Vue3 from '@vue/runtime-core/dist/runtime-core';
 import { arrayProp } from '../../src/prop-types/array';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';
@@ -27,6 +28,13 @@ describe('arrayProp().optional', () => {
     expectNotAssignable<Vue2_7.PropOptions<unknown[]>>(arrayProp().optional);
     expectNotAssignable<Vue2_7.PropOptions<string[]>>(arrayProp<string>().optional);
   });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<unknown[] | undefined>>(arrayProp().optional);
+    expectAssignable<Vue3.Prop<string[] | undefined>>(arrayProp<string>().optional);
+    expectNotAssignable<Vue3.Prop<unknown[]>>(arrayProp().optional);
+    expectNotAssignable<Vue3.Prop<string[]>>(arrayProp<string>().optional);
+  });
 });
 
 describe('arrayProp().withDefault', () => {
@@ -44,6 +52,12 @@ describe('arrayProp().withDefault', () => {
     expectAssignable<Vue2_7.PropOptions<unknown[]>>(arrayProp().withDefault(() => ['foo', 'bar']));
     expectNotAssignable<Vue2_7.PropOptions<string[]>>(arrayProp().withDefault(() => ['foo', 'bar']));
     expectAssignable<Vue2_7.PropOptions<string[]>>(arrayProp<string>().withDefault(() => ['foo', 'bar']));
+  });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<unknown[]>>(arrayProp().withDefault(() => ['foo', 'bar']));
+    expectNotAssignable<Vue3.Prop<string[]>>(arrayProp().withDefault(() => ['foo', 'bar']));
+    expectAssignable<Vue3.Prop<string[]>>(arrayProp<string>().withDefault(() => ['foo', 'bar']));
   });
 });
 
@@ -66,5 +80,11 @@ describe('arrayProp().required', () => {
     expectAssignable<Vue2_7.PropOptions<unknown[]>>(arrayProp().required);
     expectAssignable<Vue2_7.PropOptions<string[]>>(arrayProp<string>().required);
     expectNotAssignable<Vue2_7.PropOptions<number[]>>(arrayProp<string>().required);
+  });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<unknown[]>>(arrayProp().required);
+    expectAssignable<Vue3.Prop<string[]>>(arrayProp<string>().required);
+    expectNotAssignable<Vue3.Prop<number[]>>(arrayProp<string>().required);
   });
 });

--- a/type-tests/prop-types/array.type.spec.ts
+++ b/type-tests/prop-types/array.type.spec.ts
@@ -1,16 +1,16 @@
 import { expectAssignable, expectNotAssignable, expectType } from 'tsd-lite';
-import type * as Vue2 from 'vue/types/options';
-import type * as CompositionApi from '@vue/composition-api';
+import type * as Vue2_6 from 'vue2-6/types/options';
+import type * as Vue2_7 from 'vue2-7/types/options';
 import { arrayProp } from '../../src/prop-types/array';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';
 
 describe('arrayProp().optional', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<unknown[] | undefined>>(arrayProp().optional);
-    expectAssignable<Vue2.PropOptions<string[] | undefined>>(arrayProp<string>().optional);
-    expectNotAssignable<Vue2.PropOptions<unknown[]>>(arrayProp().optional);
-    expectNotAssignable<Vue2.PropOptions<string[]>>(arrayProp<string>().optional);
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<unknown[] | undefined>>(arrayProp().optional);
+    expectAssignable<Vue2_6.PropOptions<string[] | undefined>>(arrayProp<string>().optional);
+    expectNotAssignable<Vue2_6.PropOptions<unknown[]>>(arrayProp().optional);
+    expectNotAssignable<Vue2_6.PropOptions<string[]>>(arrayProp<string>().optional);
 
     expectType<Vue2ComponentWithProp<unknown[] | undefined>>(
       createVue2Component(arrayProp().optional),
@@ -21,37 +21,37 @@ describe('arrayProp().optional', () => {
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<unknown[] | undefined>>(arrayProp().optional);
-    expectAssignable<CompositionApi.PropOptions<string[] | undefined>>(arrayProp<string>().optional);
-    expectNotAssignable<CompositionApi.PropOptions<unknown[]>>(arrayProp().optional);
-    expectNotAssignable<CompositionApi.PropOptions<string[]>>(arrayProp<string>().optional);
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<unknown[] | undefined>>(arrayProp().optional);
+    expectAssignable<Vue2_7.PropOptions<string[] | undefined>>(arrayProp<string>().optional);
+    expectNotAssignable<Vue2_7.PropOptions<unknown[]>>(arrayProp().optional);
+    expectNotAssignable<Vue2_7.PropOptions<string[]>>(arrayProp<string>().optional);
   });
 });
 
 describe('arrayProp().withDefault', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<unknown[]>>(arrayProp().withDefault(() => ['foo', 'bar']));
-    expectNotAssignable<Vue2.PropOptions<string[]>>(arrayProp().withDefault(() => ['foo', 'bar']));
-    expectAssignable<Vue2.PropOptions<string[]>>(arrayProp<string>().withDefault(() => ['foo', 'bar']));
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<unknown[]>>(arrayProp().withDefault(() => ['foo', 'bar']));
+    expectNotAssignable<Vue2_6.PropOptions<string[]>>(arrayProp().withDefault(() => ['foo', 'bar']));
+    expectAssignable<Vue2_6.PropOptions<string[]>>(arrayProp<string>().withDefault(() => ['foo', 'bar']));
 
     expectType<Vue2ComponentWithProp<string[]>>(
       createVue2Component(arrayProp<string>().withDefault(() => ['foo', 'bar'])),
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<unknown[]>>(arrayProp().withDefault(() => ['foo', 'bar']));
-    expectNotAssignable<CompositionApi.PropOptions<string[]>>(arrayProp().withDefault(() => ['foo', 'bar']));
-    expectAssignable<CompositionApi.PropOptions<string[]>>(arrayProp<string>().withDefault(() => ['foo', 'bar']));
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<unknown[]>>(arrayProp().withDefault(() => ['foo', 'bar']));
+    expectNotAssignable<Vue2_7.PropOptions<string[]>>(arrayProp().withDefault(() => ['foo', 'bar']));
+    expectAssignable<Vue2_7.PropOptions<string[]>>(arrayProp<string>().withDefault(() => ['foo', 'bar']));
   });
 });
 
 describe('arrayProp().required', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<unknown[]>>(arrayProp().required);
-    expectAssignable<Vue2.PropOptions<string[]>>(arrayProp<string>().required);
-    expectNotAssignable<Vue2.PropOptions<number[]>>(arrayProp<string>().required);
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<unknown[]>>(arrayProp().required);
+    expectAssignable<Vue2_6.PropOptions<string[]>>(arrayProp<string>().required);
+    expectNotAssignable<Vue2_6.PropOptions<number[]>>(arrayProp<string>().required);
 
     expectType<Vue2ComponentWithProp<unknown[]>>(
       createVue2Component(arrayProp().required),
@@ -62,9 +62,9 @@ describe('arrayProp().required', () => {
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<unknown[]>>(arrayProp().required);
-    expectAssignable<CompositionApi.PropOptions<string[]>>(arrayProp<string>().required);
-    expectNotAssignable<CompositionApi.PropOptions<number[]>>(arrayProp<string>().required);
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<unknown[]>>(arrayProp().required);
+    expectAssignable<Vue2_7.PropOptions<string[]>>(arrayProp<string>().required);
+    expectNotAssignable<Vue2_7.PropOptions<number[]>>(arrayProp<string>().required);
   });
 });

--- a/type-tests/prop-types/boolean.type.spec.ts
+++ b/type-tests/prop-types/boolean.type.spec.ts
@@ -1,6 +1,7 @@
 import { expectAssignable, expectNotAssignable, expectType } from 'tsd-lite';
 import type * as Vue2_6 from 'vue2-6/types/options';
 import type * as Vue2_7 from 'vue2-7/types/options';
+import type * as Vue3 from '@vue/runtime-core/dist/runtime-core';
 import { booleanProp } from '../../src/prop-types/boolean';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';
@@ -19,6 +20,11 @@ describe('booleanProp().optional', () => {
     expectAssignable<Vue2_7.PropOptions<boolean | undefined>>(booleanProp().optional);
     expectNotAssignable<Vue2_7.PropOptions<boolean>>(booleanProp().optional);
   });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<boolean | undefined>>(booleanProp().optional);
+    expectNotAssignable<Vue3.Prop<boolean>>(booleanProp().optional);
+  });
 });
 
 describe('booleanProp().withDefault(false)', () => {
@@ -35,6 +41,11 @@ describe('booleanProp().withDefault(false)', () => {
     expectAssignable<Vue2_7.PropOptions<boolean>>(booleanProp().withDefault(false));
     expectNotAssignable<Vue2_7.PropOptions<string>>(booleanProp().withDefault(false));
   });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<boolean>>(booleanProp().withDefault(false));
+    expectNotAssignable<Vue3.Prop<string>>(booleanProp().withDefault(false));
+  });
 });
 
 describe('booleanProp().required', () => {
@@ -50,5 +61,10 @@ describe('booleanProp().required', () => {
   describe('Vue 2.7', () => {
     expectAssignable<Vue2_7.PropOptions<boolean>>(booleanProp().required);
     expectNotAssignable<Vue2_7.PropOptions<string>>(booleanProp().required);
+  });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<boolean>>(booleanProp().required);
+    expectNotAssignable<Vue3.Prop<string>>(booleanProp().required);
   });
 });

--- a/type-tests/prop-types/boolean.type.spec.ts
+++ b/type-tests/prop-types/boolean.type.spec.ts
@@ -1,54 +1,54 @@
 import { expectAssignable, expectNotAssignable, expectType } from 'tsd-lite';
-import type * as Vue2 from 'vue/types/options';
-import type * as CompositionApi from '@vue/composition-api';
+import type * as Vue2_6 from 'vue2-6/types/options';
+import type * as Vue2_7 from 'vue2-7/types/options';
 import { booleanProp } from '../../src/prop-types/boolean';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';
 
 describe('booleanProp().optional', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<boolean | undefined>>(booleanProp().optional);
-    expectNotAssignable<Vue2.PropOptions<boolean>>(booleanProp().optional);
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<boolean | undefined>>(booleanProp().optional);
+    expectNotAssignable<Vue2_6.PropOptions<boolean>>(booleanProp().optional);
 
     expectType<Vue2ComponentWithProp<boolean | undefined>>(
       createVue2Component(booleanProp().optional),
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<boolean | undefined>>(booleanProp().optional);
-    expectNotAssignable<CompositionApi.PropOptions<boolean>>(booleanProp().optional);
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<boolean | undefined>>(booleanProp().optional);
+    expectNotAssignable<Vue2_7.PropOptions<boolean>>(booleanProp().optional);
   });
 });
 
 describe('booleanProp().withDefault(false)', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<boolean>>(booleanProp().withDefault(false));
-    expectNotAssignable<Vue2.PropOptions<string>>(booleanProp().withDefault(false));
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<boolean>>(booleanProp().withDefault(false));
+    expectNotAssignable<Vue2_6.PropOptions<string>>(booleanProp().withDefault(false));
 
     expectType<Vue2ComponentWithProp<boolean>>(
       createVue2Component(booleanProp().withDefault(false)),
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<boolean>>(booleanProp().withDefault(false));
-    expectNotAssignable<CompositionApi.PropOptions<string>>(booleanProp().withDefault(false));
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<boolean>>(booleanProp().withDefault(false));
+    expectNotAssignable<Vue2_7.PropOptions<string>>(booleanProp().withDefault(false));
   });
 });
 
 describe('booleanProp().required', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<boolean>>(booleanProp().required);
-    expectNotAssignable<Vue2.PropOptions<string>>(booleanProp().required);
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<boolean>>(booleanProp().required);
+    expectNotAssignable<Vue2_6.PropOptions<string>>(booleanProp().required);
 
     expectType<Vue2ComponentWithProp<boolean>>(
       createVue2Component(booleanProp().required),
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<boolean>>(booleanProp().required);
-    expectNotAssignable<CompositionApi.PropOptions<string>>(booleanProp().required);
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<boolean>>(booleanProp().required);
+    expectNotAssignable<Vue2_7.PropOptions<string>>(booleanProp().required);
   });
 });

--- a/type-tests/prop-types/function.type.spec.ts
+++ b/type-tests/prop-types/function.type.spec.ts
@@ -1,6 +1,6 @@
 import { expectAssignable, expectNotAssignable, expectType } from 'tsd-lite';
-import type * as Vue2 from 'vue/types/options';
-import type * as CompositionApi from '@vue/composition-api';
+import type * as Vue2_6 from 'vue2-6/types/options';
+import type * as Vue2_7 from 'vue2-7/types/options';
 import { functionProp } from '../../src/prop-types/function';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';
@@ -10,11 +10,11 @@ import type { Vue2ComponentWithProp } from '../utils';
 type MyCustomCallback = (parameter: string) => Promise<boolean>
 
 describe('functionProp().optional', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<Function | undefined>>(functionProp().optional);
-    expectAssignable<Vue2.PropOptions<MyCustomCallback | undefined>>(functionProp<MyCustomCallback>().optional);
-    expectNotAssignable<Vue2.PropOptions<Function>>(functionProp().optional);
-    expectNotAssignable<Vue2.PropOptions<MyCustomCallback>>(functionProp<MyCustomCallback>().optional);
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<Function | undefined>>(functionProp().optional);
+    expectAssignable<Vue2_6.PropOptions<MyCustomCallback | undefined>>(functionProp<MyCustomCallback>().optional);
+    expectNotAssignable<Vue2_6.PropOptions<Function>>(functionProp().optional);
+    expectNotAssignable<Vue2_6.PropOptions<MyCustomCallback>>(functionProp<MyCustomCallback>().optional);
 
     expectType<Vue2ComponentWithProp<Function | undefined>>(
       createVue2Component(functionProp().optional),
@@ -25,19 +25,19 @@ describe('functionProp().optional', () => {
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<Function | undefined>>(functionProp().optional);
-    expectAssignable<CompositionApi.PropOptions<MyCustomCallback | undefined>>(functionProp<MyCustomCallback>().optional);
-    expectNotAssignable<CompositionApi.PropOptions<Function>>(functionProp().optional);
-    expectNotAssignable<CompositionApi.PropOptions<MyCustomCallback>>(functionProp<MyCustomCallback>().optional);
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<Function | undefined>>(functionProp().optional);
+    expectAssignable<Vue2_7.PropOptions<MyCustomCallback | undefined>>(functionProp<MyCustomCallback>().optional);
+    expectNotAssignable<Vue2_7.PropOptions<Function>>(functionProp().optional);
+    expectNotAssignable<Vue2_7.PropOptions<MyCustomCallback>>(functionProp<MyCustomCallback>().optional);
   });
 });
 
 describe('functionProp().required', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<Function>>(functionProp().required);
-    expectAssignable<Vue2.PropOptions<MyCustomCallback>>(functionProp<MyCustomCallback>().required);
-    expectNotAssignable<Vue2.PropOptions<string>>(functionProp().required);
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<Function>>(functionProp().required);
+    expectAssignable<Vue2_6.PropOptions<MyCustomCallback>>(functionProp<MyCustomCallback>().required);
+    expectNotAssignable<Vue2_6.PropOptions<string>>(functionProp().required);
 
     expectType<Vue2ComponentWithProp<Function>>(
       createVue2Component(functionProp().required),
@@ -48,9 +48,9 @@ describe('functionProp().required', () => {
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<Function>>(functionProp().required);
-    expectAssignable<CompositionApi.PropOptions<MyCustomCallback>>(functionProp<MyCustomCallback>().required);
-    expectNotAssignable<CompositionApi.PropOptions<string>>(functionProp().required);
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<Function>>(functionProp().required);
+    expectAssignable<Vue2_7.PropOptions<MyCustomCallback>>(functionProp<MyCustomCallback>().required);
+    expectNotAssignable<Vue2_7.PropOptions<string>>(functionProp().required);
   });
 });

--- a/type-tests/prop-types/function.type.spec.ts
+++ b/type-tests/prop-types/function.type.spec.ts
@@ -1,6 +1,7 @@
 import { expectAssignable, expectNotAssignable, expectType } from 'tsd-lite';
 import type * as Vue2_6 from 'vue2-6/types/options';
 import type * as Vue2_7 from 'vue2-7/types/options';
+import type * as Vue3 from '@vue/runtime-core/dist/runtime-core';
 import { functionProp } from '../../src/prop-types/function';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';
@@ -31,6 +32,13 @@ describe('functionProp().optional', () => {
     expectNotAssignable<Vue2_7.PropOptions<Function>>(functionProp().optional);
     expectNotAssignable<Vue2_7.PropOptions<MyCustomCallback>>(functionProp<MyCustomCallback>().optional);
   });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<Function | undefined>>(functionProp().optional);
+    expectAssignable<Vue3.Prop<MyCustomCallback | undefined>>(functionProp<MyCustomCallback>().optional);
+    expectNotAssignable<Vue3.Prop<Function>>(functionProp().optional);
+    expectNotAssignable<Vue3.Prop<MyCustomCallback>>(functionProp<MyCustomCallback>().optional);
+  });
 });
 
 describe('functionProp().required', () => {
@@ -52,5 +60,11 @@ describe('functionProp().required', () => {
     expectAssignable<Vue2_7.PropOptions<Function>>(functionProp().required);
     expectAssignable<Vue2_7.PropOptions<MyCustomCallback>>(functionProp<MyCustomCallback>().required);
     expectNotAssignable<Vue2_7.PropOptions<string>>(functionProp().required);
+  });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<Function>>(functionProp().required);
+    expectAssignable<Vue3.Prop<MyCustomCallback>>(functionProp<MyCustomCallback>().required);
+    expectNotAssignable<Vue3.Prop<string>>(functionProp().required);
   });
 });

--- a/type-tests/prop-types/instanceOf.type.spec.ts
+++ b/type-tests/prop-types/instanceOf.type.spec.ts
@@ -1,6 +1,6 @@
 import { expectAssignable, expectNotAssignable, expectType } from 'tsd-lite';
-import type * as Vue2 from 'vue/types/options';
-import type * as CompositionApi from '@vue/composition-api';
+import type * as Vue2_6 from 'vue2-6/types/options';
+import type * as Vue2_7 from 'vue2-7/types/options';
 import { instanceOfProp } from '../../src/prop-types/instanceOf';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';
@@ -13,49 +13,49 @@ class Account {
 }
 
 describe('instanceOfProp().optional', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<User | undefined>>(instanceOfProp(User).optional);
-    expectNotAssignable<Vue2.PropOptions<Account | undefined>>(instanceOfProp(User).optional);
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<User | undefined>>(instanceOfProp(User).optional);
+    expectNotAssignable<Vue2_6.PropOptions<Account | undefined>>(instanceOfProp(User).optional);
 
     expectType<Vue2ComponentWithProp<User | undefined>>(
       createVue2Component(instanceOfProp(User).optional),
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<User | undefined>>(instanceOfProp(User).optional);
-    expectNotAssignable<CompositionApi.PropOptions<Account>>(instanceOfProp(User).optional);
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<User | undefined>>(instanceOfProp(User).optional);
+    expectNotAssignable<Vue2_7.PropOptions<Account>>(instanceOfProp(User).optional);
   });
 });
 
 describe('instanceOfProp().withDefault', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<User>>(instanceOfProp(User).withDefault(() => new User()));
-    expectNotAssignable<Vue2.PropOptions<Account>>(instanceOfProp(User).withDefault(() => new User()));
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<User>>(instanceOfProp(User).withDefault(() => new User()));
+    expectNotAssignable<Vue2_6.PropOptions<Account>>(instanceOfProp(User).withDefault(() => new User()));
 
     expectType<Vue2ComponentWithProp<User>>(
       createVue2Component(instanceOfProp(User).withDefault(() => new User())),
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<User>>(instanceOfProp(User).withDefault(() => new User()));
-    expectNotAssignable<CompositionApi.PropOptions<Account>>(instanceOfProp(User).withDefault(() => new User()));
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<User>>(instanceOfProp(User).withDefault(() => new User()));
+    expectNotAssignable<Vue2_7.PropOptions<Account>>(instanceOfProp(User).withDefault(() => new User()));
   });
 });
 
 describe('instanceOfProp().required', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<User>>(instanceOfProp(User).required);
-    expectNotAssignable<Vue2.PropOptions<Account>>(instanceOfProp(User).required);
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<User>>(instanceOfProp(User).required);
+    expectNotAssignable<Vue2_6.PropOptions<Account>>(instanceOfProp(User).required);
 
     expectType<Vue2ComponentWithProp<User>>(
       createVue2Component(instanceOfProp(User).required),
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<User>>(instanceOfProp(User).required);
-    expectNotAssignable<CompositionApi.PropOptions<Account>>(instanceOfProp(User).required);
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<User>>(instanceOfProp(User).required);
+    expectNotAssignable<Vue2_7.PropOptions<Account>>(instanceOfProp(User).required);
   });
 });

--- a/type-tests/prop-types/instanceOf.type.spec.ts
+++ b/type-tests/prop-types/instanceOf.type.spec.ts
@@ -1,6 +1,7 @@
 import { expectAssignable, expectNotAssignable, expectType } from 'tsd-lite';
 import type * as Vue2_6 from 'vue2-6/types/options';
 import type * as Vue2_7 from 'vue2-7/types/options';
+import type * as Vue3 from '@vue/runtime-core/dist/runtime-core';
 import { instanceOfProp } from '../../src/prop-types/instanceOf';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';
@@ -26,6 +27,11 @@ describe('instanceOfProp().optional', () => {
     expectAssignable<Vue2_7.PropOptions<User | undefined>>(instanceOfProp(User).optional);
     expectNotAssignable<Vue2_7.PropOptions<Account>>(instanceOfProp(User).optional);
   });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<User | undefined>>(instanceOfProp(User).optional);
+    expectNotAssignable<Vue3.Prop<Account>>(instanceOfProp(User).optional);
+  });
 });
 
 describe('instanceOfProp().withDefault', () => {
@@ -42,6 +48,11 @@ describe('instanceOfProp().withDefault', () => {
     expectAssignable<Vue2_7.PropOptions<User>>(instanceOfProp(User).withDefault(() => new User()));
     expectNotAssignable<Vue2_7.PropOptions<Account>>(instanceOfProp(User).withDefault(() => new User()));
   });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<User>>(instanceOfProp(User).withDefault(() => new User()));
+    expectNotAssignable<Vue3.Prop<Account>>(instanceOfProp(User).withDefault(() => new User()));
+  });
 });
 
 describe('instanceOfProp().required', () => {
@@ -57,5 +68,10 @@ describe('instanceOfProp().required', () => {
   describe('Vue 2.7', () => {
     expectAssignable<Vue2_7.PropOptions<User>>(instanceOfProp(User).required);
     expectNotAssignable<Vue2_7.PropOptions<Account>>(instanceOfProp(User).required);
+  });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<User>>(instanceOfProp(User).required);
+    expectNotAssignable<Vue3.Prop<Account>>(instanceOfProp(User).required);
   });
 });

--- a/type-tests/prop-types/integer.type.spec.ts
+++ b/type-tests/prop-types/integer.type.spec.ts
@@ -1,6 +1,7 @@
 import { expectAssignable, expectNotAssignable, expectType } from 'tsd-lite';
 import type * as Vue2_6 from 'vue2-6/types/options';
 import type * as Vue2_7 from 'vue2-7/types/options';
+import type * as Vue3 from '@vue/runtime-core/dist/runtime-core';
 import { integerProp } from '../../src/prop-types/integer';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';
@@ -19,6 +20,11 @@ describe('integerProp().optional', () => {
     expectAssignable<Vue2_7.PropOptions<number | undefined>>(integerProp().optional);
     expectNotAssignable<Vue2_7.PropOptions<number>>(integerProp().optional);
   });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<number | undefined>>(integerProp().optional);
+    expectNotAssignable<Vue3.Prop<number>>(integerProp().optional);
+  });
 });
 
 describe('integerProp().withDefault', () => {
@@ -35,6 +41,11 @@ describe('integerProp().withDefault', () => {
     expectAssignable<Vue2_7.PropOptions<number>>(integerProp().withDefault(27));
     expectNotAssignable<Vue2_7.PropOptions<string>>(integerProp().withDefault(27));
   });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<number>>(integerProp().withDefault(27));
+    expectNotAssignable<Vue3.Prop<string>>(integerProp().withDefault(27));
+  });
 });
 
 describe('integerProp().required', () => {
@@ -50,5 +61,10 @@ describe('integerProp().required', () => {
   describe('Vue 2.7', () => {
     expectAssignable<Vue2_7.PropOptions<number>>(integerProp().required);
     expectNotAssignable<Vue2_7.PropOptions<string>>(integerProp().required);
+  });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<number>>(integerProp().required);
+    expectNotAssignable<Vue3.Prop<string>>(integerProp().required);
   });
 });

--- a/type-tests/prop-types/integer.type.spec.ts
+++ b/type-tests/prop-types/integer.type.spec.ts
@@ -1,54 +1,54 @@
 import { expectAssignable, expectNotAssignable, expectType } from 'tsd-lite';
-import type * as Vue2 from 'vue/types/options';
-import type * as CompositionApi from '@vue/composition-api';
+import type * as Vue2_6 from 'vue2-6/types/options';
+import type * as Vue2_7 from 'vue2-7/types/options';
 import { integerProp } from '../../src/prop-types/integer';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';
 
 describe('integerProp().optional', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<number | undefined>>(integerProp().optional);
-    expectNotAssignable<Vue2.PropOptions<number>>(integerProp().optional);
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<number | undefined>>(integerProp().optional);
+    expectNotAssignable<Vue2_6.PropOptions<number>>(integerProp().optional);
 
     expectType<Vue2ComponentWithProp<number | undefined>>(
       createVue2Component(integerProp().optional),
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<number | undefined>>(integerProp().optional);
-    expectNotAssignable<CompositionApi.PropOptions<number>>(integerProp().optional);
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<number | undefined>>(integerProp().optional);
+    expectNotAssignable<Vue2_7.PropOptions<number>>(integerProp().optional);
   });
 });
 
 describe('integerProp().withDefault', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<number>>(integerProp().withDefault(27));
-    expectNotAssignable<Vue2.PropOptions<string>>(integerProp().withDefault(27));
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<number>>(integerProp().withDefault(27));
+    expectNotAssignable<Vue2_6.PropOptions<string>>(integerProp().withDefault(27));
 
     expectType<Vue2ComponentWithProp<number>>(
       createVue2Component(integerProp().withDefault(27)),
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<number>>(integerProp().withDefault(27));
-    expectNotAssignable<CompositionApi.PropOptions<string>>(integerProp().withDefault(27));
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<number>>(integerProp().withDefault(27));
+    expectNotAssignable<Vue2_7.PropOptions<string>>(integerProp().withDefault(27));
   });
 });
 
 describe('integerProp().required', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<number>>(integerProp().required);
-    expectNotAssignable<Vue2.PropOptions<string>>(integerProp().required);
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<number>>(integerProp().required);
+    expectNotAssignable<Vue2_6.PropOptions<string>>(integerProp().required);
 
     expectType<Vue2ComponentWithProp<number>>(
       createVue2Component(integerProp().required),
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<number>>(integerProp().required);
-    expectNotAssignable<CompositionApi.PropOptions<string>>(integerProp().required);
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<number>>(integerProp().required);
+    expectNotAssignable<Vue2_7.PropOptions<string>>(integerProp().required);
   });
 });

--- a/type-tests/prop-types/number.type.spec.ts
+++ b/type-tests/prop-types/number.type.spec.ts
@@ -1,6 +1,7 @@
 import { expectAssignable, expectNotAssignable, expectType } from 'tsd-lite';
 import type * as Vue2_6 from 'vue2-6/types/options';
 import type * as Vue2_7 from 'vue2-7/types/options';
+import type * as Vue3 from '@vue/runtime-core/dist/runtime-core';
 import { numberProp } from '../../src/prop-types/number';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';
@@ -19,6 +20,11 @@ describe('numberProp().optional', () => {
     expectAssignable<Vue2_7.PropOptions<number | undefined>>(numberProp().optional);
     expectNotAssignable<Vue2_7.PropOptions<number>>(numberProp().optional);
   });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<number | undefined>>(numberProp().optional);
+    expectNotAssignable<Vue3.Prop<number>>(numberProp().optional);
+  });
 });
 
 describe('numberProp().withDefault', () => {
@@ -35,6 +41,11 @@ describe('numberProp().withDefault', () => {
     expectAssignable<Vue2_7.PropOptions<number>>(numberProp().withDefault(27));
     expectNotAssignable<Vue2_7.PropOptions<string>>(numberProp().withDefault(27));
   });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<number>>(numberProp().withDefault(27));
+    expectNotAssignable<Vue3.Prop<string>>(numberProp().withDefault(27));
+  });
 });
 
 describe('numberProp().required', () => {
@@ -50,5 +61,10 @@ describe('numberProp().required', () => {
   describe('Vue 2.7', () => {
     expectAssignable<Vue2_7.PropOptions<number>>(numberProp().required);
     expectNotAssignable<Vue2_7.PropOptions<string>>(numberProp().required);
+  });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<number>>(numberProp().required);
+    expectNotAssignable<Vue3.Prop<string>>(numberProp().required);
   });
 });

--- a/type-tests/prop-types/number.type.spec.ts
+++ b/type-tests/prop-types/number.type.spec.ts
@@ -1,54 +1,54 @@
 import { expectAssignable, expectNotAssignable, expectType } from 'tsd-lite';
-import type * as Vue2 from 'vue/types/options';
-import type * as CompositionApi from '@vue/composition-api';
+import type * as Vue2_6 from 'vue2-6/types/options';
+import type * as Vue2_7 from 'vue2-7/types/options';
 import { numberProp } from '../../src/prop-types/number';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';
 
 describe('numberProp().optional', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<number | undefined>>(numberProp().optional);
-    expectNotAssignable<Vue2.PropOptions<number>>(numberProp().optional);
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<number | undefined>>(numberProp().optional);
+    expectNotAssignable<Vue2_6.PropOptions<number>>(numberProp().optional);
 
     expectType<Vue2ComponentWithProp<number | undefined>>(
       createVue2Component(numberProp().optional),
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<number | undefined>>(numberProp().optional);
-    expectNotAssignable<CompositionApi.PropOptions<number>>(numberProp().optional);
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<number | undefined>>(numberProp().optional);
+    expectNotAssignable<Vue2_7.PropOptions<number>>(numberProp().optional);
   });
 });
 
 describe('numberProp().withDefault', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<number>>(numberProp().withDefault(27));
-    expectNotAssignable<Vue2.PropOptions<string>>(numberProp().withDefault(27));
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<number>>(numberProp().withDefault(27));
+    expectNotAssignable<Vue2_6.PropOptions<string>>(numberProp().withDefault(27));
 
     expectType<Vue2ComponentWithProp<number>>(
       createVue2Component(numberProp().withDefault(27)),
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<number>>(numberProp().withDefault(27));
-    expectNotAssignable<CompositionApi.PropOptions<string>>(numberProp().withDefault(27));
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<number>>(numberProp().withDefault(27));
+    expectNotAssignable<Vue2_7.PropOptions<string>>(numberProp().withDefault(27));
   });
 });
 
 describe('numberProp().required', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<number>>(numberProp().required);
-    expectNotAssignable<Vue2.PropOptions<string>>(numberProp().required);
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<number>>(numberProp().required);
+    expectNotAssignable<Vue2_6.PropOptions<string>>(numberProp().required);
 
     expectType<Vue2ComponentWithProp<number>>(
       createVue2Component(numberProp().required),
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<number>>(numberProp().required);
-    expectNotAssignable<CompositionApi.PropOptions<string>>(numberProp().required);
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<number>>(numberProp().required);
+    expectNotAssignable<Vue2_7.PropOptions<string>>(numberProp().required);
   });
 });

--- a/type-tests/prop-types/object.type.spec.ts
+++ b/type-tests/prop-types/object.type.spec.ts
@@ -1,6 +1,7 @@
 import { expectAssignable, expectNotAssignable, expectType } from 'tsd-lite';
 import type * as Vue2_6 from 'vue2-6/types/options';
 import type * as Vue2_7 from 'vue2-7/types/options';
+import type * as Vue3 from '@vue/runtime-core/dist/runtime-core';
 import { objectProp } from '../../src/prop-types/object';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';
@@ -29,6 +30,12 @@ describe('objectProp().optional', () => {
     expectAssignable<Vue2_7.PropOptions<User | undefined>>(objectProp<User>().optional);
     expectNotAssignable<Vue2_7.PropOptions<User>>(objectProp<User>().optional);
   });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<object | undefined>>(objectProp().optional);
+    expectAssignable<Vue3.Prop<User | undefined>>(objectProp<User>().optional);
+    expectNotAssignable<Vue3.Prop<User>>(objectProp<User>().optional);
+  });
 });
 
 const userGenerator = () => ({ name: 'bar' });
@@ -44,6 +51,10 @@ describe('objectProp().withDefault', () => {
 
   describe('Vue 2.7', () => {
     expectAssignable<Vue2_7.PropOptions<User>>(objectProp<User>().withDefault(userGenerator));
+  });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<User>>(objectProp<User>().withDefault(userGenerator));
   });
 });
 
@@ -64,5 +75,10 @@ describe('objectProp().required', () => {
   describe('Vue 2.7', () => {
     expectAssignable<Vue2_7.PropOptions<object>>(objectProp().required);
     expectAssignable<Vue2_7.PropOptions<User>>(objectProp<User>().required);
+  });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<object>>(objectProp().required);
+    expectAssignable<Vue3.Prop<User>>(objectProp<User>().required);
   });
 });

--- a/type-tests/prop-types/object.type.spec.ts
+++ b/type-tests/prop-types/object.type.spec.ts
@@ -1,6 +1,6 @@
 import { expectAssignable, expectNotAssignable, expectType } from 'tsd-lite';
-import type * as Vue2 from 'vue/types/options';
-import type * as CompositionApi from '@vue/composition-api';
+import type * as Vue2_6 from 'vue2-6/types/options';
+import type * as Vue2_7 from 'vue2-7/types/options';
 import { objectProp } from '../../src/prop-types/object';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';
@@ -10,10 +10,10 @@ interface User {
 }
 
 describe('objectProp().optional', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<object | undefined>>(objectProp().optional);
-    expectAssignable<Vue2.PropOptions<User | undefined>>(objectProp<User>().optional);
-    expectNotAssignable<Vue2.PropOptions<User>>(objectProp<User>().optional);
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<object | undefined>>(objectProp().optional);
+    expectAssignable<Vue2_6.PropOptions<User | undefined>>(objectProp<User>().optional);
+    expectNotAssignable<Vue2_6.PropOptions<User>>(objectProp<User>().optional);
 
     expectType<Vue2ComponentWithProp<object | undefined>>(
       createVue2Component(objectProp().optional),
@@ -24,33 +24,33 @@ describe('objectProp().optional', () => {
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<object | undefined>>(objectProp().optional);
-    expectAssignable<CompositionApi.PropOptions<User | undefined>>(objectProp<User>().optional);
-    expectNotAssignable<CompositionApi.PropOptions<User>>(objectProp<User>().optional);
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<object | undefined>>(objectProp().optional);
+    expectAssignable<Vue2_7.PropOptions<User | undefined>>(objectProp<User>().optional);
+    expectNotAssignable<Vue2_7.PropOptions<User>>(objectProp<User>().optional);
   });
 });
 
 const userGenerator = () => ({ name: 'bar' });
 
 describe('objectProp().withDefault', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<User>>(objectProp<User>().withDefault(userGenerator));
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<User>>(objectProp<User>().withDefault(userGenerator));
 
     expectType<Vue2ComponentWithProp<User>>(
       createVue2Component(objectProp<User>().withDefault(userGenerator)),
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<User>>(objectProp<User>().withDefault(userGenerator));
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<User>>(objectProp<User>().withDefault(userGenerator));
   });
 });
 
 describe('objectProp().required', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<object>>(objectProp().required);
-    expectAssignable<Vue2.PropOptions<User>>(objectProp<User>().required);
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<object>>(objectProp().required);
+    expectAssignable<Vue2_6.PropOptions<User>>(objectProp<User>().required);
 
     expectType<Vue2ComponentWithProp<object>>(
       createVue2Component(objectProp().required),
@@ -61,8 +61,8 @@ describe('objectProp().required', () => {
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<object>>(objectProp().required);
-    expectAssignable<CompositionApi.PropOptions<User>>(objectProp<User>().required);
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<object>>(objectProp().required);
+    expectAssignable<Vue2_7.PropOptions<User>>(objectProp<User>().required);
   });
 });

--- a/type-tests/prop-types/oneOf.type.spec.ts
+++ b/type-tests/prop-types/oneOf.type.spec.ts
@@ -1,6 +1,7 @@
 import { expectAssignable, expectType } from 'tsd-lite';
 import type * as Vue2_6 from 'vue2-6/types/options';
 import type * as Vue2_7 from 'vue2-7/types/options';
+import type * as Vue3 from '@vue/runtime-core/dist/runtime-core';
 import { oneOfProp } from '../../src/prop-types/oneOf';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';
@@ -22,6 +23,11 @@ describe('oneOfProp().optional', () => {
     expectAssignable<Vue2_7.PropOptions<string | undefined>>(oneOfProp(['a', 'b', 'c']).optional);
     expectAssignable<Vue2_7.PropOptions<Options | undefined>>(oneOfProp(options).optional);
   });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<string | undefined>>(oneOfProp(['a', 'b', 'c']).optional);
+    expectAssignable<Vue3.Prop<Options | undefined>>(oneOfProp(options).optional);
+  });
 });
 
 describe('oneOfProp().withDefault', () => {
@@ -36,6 +42,10 @@ describe('oneOfProp().withDefault', () => {
   describe('Vue 2.7', () => {
     expectAssignable<Vue2_7.PropOptions<Options>>(oneOfProp(options).withDefault('a'));
   });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<Options>>(oneOfProp(options).withDefault('a'));
+  });
 });
 
 describe('oneOfProp().required', () => {
@@ -49,5 +59,9 @@ describe('oneOfProp().required', () => {
 
   describe('Vue 2.7', () => {
     expectAssignable<Vue2_7.PropOptions<Options>>(oneOfProp(options).required);
+  });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<Options>>(oneOfProp(options).required);
   });
 });

--- a/type-tests/prop-types/oneOf.type.spec.ts
+++ b/type-tests/prop-types/oneOf.type.spec.ts
@@ -1,6 +1,6 @@
 import { expectAssignable, expectType } from 'tsd-lite';
-import type * as Vue2 from 'vue/types/options';
-import type * as CompositionApi from '@vue/composition-api';
+import type * as Vue2_6 from 'vue2-6/types/options';
+import type * as Vue2_7 from 'vue2-7/types/options';
 import { oneOfProp } from '../../src/prop-types/oneOf';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';
@@ -9,45 +9,45 @@ const options = ['a', 'b', 'c'] as const;
 type Options = 'a' | 'b' | 'c';
 
 describe('oneOfProp().optional', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<string | undefined>>(oneOfProp(['a', 'b', 'c']).optional);
-    expectAssignable<Vue2.PropOptions<Options | undefined>>(oneOfProp(options).optional);
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<string | undefined>>(oneOfProp(['a', 'b', 'c']).optional);
+    expectAssignable<Vue2_6.PropOptions<Options | undefined>>(oneOfProp(options).optional);
 
     expectType<Vue2ComponentWithProp<Options | undefined>>(
       createVue2Component(oneOfProp(options).optional),
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<string | undefined>>(oneOfProp(['a', 'b', 'c']).optional);
-    expectAssignable<CompositionApi.PropOptions<Options | undefined>>(oneOfProp(options).optional);
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<string | undefined>>(oneOfProp(['a', 'b', 'c']).optional);
+    expectAssignable<Vue2_7.PropOptions<Options | undefined>>(oneOfProp(options).optional);
   });
 });
 
 describe('oneOfProp().withDefault', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<Options>>(oneOfProp(options).withDefault('a'));
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<Options>>(oneOfProp(options).withDefault('a'));
 
     expectType<Vue2ComponentWithProp<Options>>(
       createVue2Component(oneOfProp(options).withDefault('a')),
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<Options>>(oneOfProp(options).withDefault('a'));
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<Options>>(oneOfProp(options).withDefault('a'));
   });
 });
 
 describe('oneOfProp().required', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<Options>>(oneOfProp(options).required);
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<Options>>(oneOfProp(options).required);
 
     expectType<Vue2ComponentWithProp<Options>>(
       createVue2Component(oneOfProp(options).required),
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<Options>>(oneOfProp(options).required);
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<Options>>(oneOfProp(options).required);
   });
 });

--- a/type-tests/prop-types/oneOfObjectKeys.type.spec.ts
+++ b/type-tests/prop-types/oneOfObjectKeys.type.spec.ts
@@ -1,6 +1,6 @@
 import { expectAssignable, expectType } from 'tsd-lite';
-import type * as Vue2 from 'vue/types/options';
-import type * as CompositionApi from '@vue/composition-api';
+import type * as Vue2_6 from 'vue2-6/types/options';
+import type * as Vue2_7 from 'vue2-7/types/options';
 import { oneOfObjectKeysProp } from '../../src/prop-types/oneOfObjectKeys';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';
@@ -9,43 +9,43 @@ const options = { a: 'a', b: 'b', c: 'c' };
 type Options = 'a' | 'b' | 'c';
 
 describe('oneOfObjectKeysProp().optional', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<Options | undefined>>(oneOfObjectKeysProp(options).optional);
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<Options | undefined>>(oneOfObjectKeysProp(options).optional);
 
     expectType<Vue2ComponentWithProp<Options | undefined>>(
       createVue2Component(oneOfObjectKeysProp(options).optional),
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<Options | undefined>>(oneOfObjectKeysProp(options).optional);
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<Options | undefined>>(oneOfObjectKeysProp(options).optional);
   });
 });
 
 describe('oneOfObjectKeysProp().withDefault', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<Options>>(oneOfObjectKeysProp(options).withDefault('a'));
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<Options>>(oneOfObjectKeysProp(options).withDefault('a'));
 
     expectType<Vue2ComponentWithProp<Options>>(
       createVue2Component(oneOfObjectKeysProp(options).withDefault('a')),
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<Options>>(oneOfObjectKeysProp(options).withDefault('a'));
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<Options>>(oneOfObjectKeysProp(options).withDefault('a'));
   });
 });
 
 describe('oneOfObjectKeysProp().required', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<Options>>(oneOfObjectKeysProp(options).required);
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<Options>>(oneOfObjectKeysProp(options).required);
 
     expectType<Vue2ComponentWithProp<Options>>(
       createVue2Component(oneOfObjectKeysProp(options).required),
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<Options>>(oneOfObjectKeysProp(options).required);
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<Options>>(oneOfObjectKeysProp(options).required);
   });
 });

--- a/type-tests/prop-types/oneOfObjectKeys.type.spec.ts
+++ b/type-tests/prop-types/oneOfObjectKeys.type.spec.ts
@@ -1,6 +1,7 @@
 import { expectAssignable, expectType } from 'tsd-lite';
 import type * as Vue2_6 from 'vue2-6/types/options';
 import type * as Vue2_7 from 'vue2-7/types/options';
+import type * as Vue3 from '@vue/runtime-core/dist/runtime-core';
 import { oneOfObjectKeysProp } from '../../src/prop-types/oneOfObjectKeys';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';
@@ -20,6 +21,10 @@ describe('oneOfObjectKeysProp().optional', () => {
   describe('Vue 2.7', () => {
     expectAssignable<Vue2_7.PropOptions<Options | undefined>>(oneOfObjectKeysProp(options).optional);
   });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<Options | undefined>>(oneOfObjectKeysProp(options).optional);
+  });
 });
 
 describe('oneOfObjectKeysProp().withDefault', () => {
@@ -34,6 +39,10 @@ describe('oneOfObjectKeysProp().withDefault', () => {
   describe('Vue 2.7', () => {
     expectAssignable<Vue2_7.PropOptions<Options>>(oneOfObjectKeysProp(options).withDefault('a'));
   });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<Options>>(oneOfObjectKeysProp(options).withDefault('a'));
+  });
 });
 
 describe('oneOfObjectKeysProp().required', () => {
@@ -47,5 +56,9 @@ describe('oneOfObjectKeysProp().required', () => {
 
   describe('Vue 2.7', () => {
     expectAssignable<Vue2_7.PropOptions<Options>>(oneOfObjectKeysProp(options).required);
+  });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<Options>>(oneOfObjectKeysProp(options).required);
   });
 });

--- a/type-tests/prop-types/oneOfTypes.type.spec.ts
+++ b/type-tests/prop-types/oneOfTypes.type.spec.ts
@@ -1,6 +1,6 @@
 import { expectAssignable, expectType } from 'tsd-lite';
-import type * as Vue2 from 'vue/types/options';
-import type * as CompositionApi from '@vue/composition-api';
+import type * as Vue2_6 from 'vue2-6/types/options';
+import type * as Vue2_7 from 'vue2-7/types/options';
 import { oneOfTypesProp } from '../../src/prop-types/oneOfTypes';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';
@@ -9,43 +9,43 @@ const options = [Number, String];
 type Options = number | string
 
 describe('oneOfTypesProp().optional', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<Options | undefined>>(oneOfTypesProp<Options>(options).optional);
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<Options | undefined>>(oneOfTypesProp<Options>(options).optional);
 
     expectType<Vue2ComponentWithProp<Options | undefined>>(
       createVue2Component(oneOfTypesProp<Options>(options).optional),
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<Options | undefined>>(oneOfTypesProp<Options>(options).optional);
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<Options | undefined>>(oneOfTypesProp<Options>(options).optional);
   });
 });
 
 describe('oneOfTypesProp().withDefault', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<Options>>(oneOfTypesProp<Options>(options).withDefault('a'));
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<Options>>(oneOfTypesProp<Options>(options).withDefault('a'));
 
     expectType<Vue2ComponentWithProp<Options>>(
       createVue2Component(oneOfTypesProp<Options>(options).withDefault('a')),
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<Options>>(oneOfTypesProp<Options>(options).withDefault('a'));
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<Options>>(oneOfTypesProp<Options>(options).withDefault('a'));
   });
 });
 
 describe('oneOfTypesProp().required', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<Options>>(oneOfTypesProp<Options>(options).required);
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<Options>>(oneOfTypesProp<Options>(options).required);
 
     expectType<Vue2ComponentWithProp<Options>>(
       createVue2Component(oneOfTypesProp<Options>(options).required),
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<Options>>(oneOfTypesProp<Options>(options).required);
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<Options>>(oneOfTypesProp<Options>(options).required);
   });
 });

--- a/type-tests/prop-types/oneOfTypes.type.spec.ts
+++ b/type-tests/prop-types/oneOfTypes.type.spec.ts
@@ -1,6 +1,7 @@
 import { expectAssignable, expectType } from 'tsd-lite';
 import type * as Vue2_6 from 'vue2-6/types/options';
 import type * as Vue2_7 from 'vue2-7/types/options';
+import type * as Vue3 from '@vue/runtime-core/dist/runtime-core';
 import { oneOfTypesProp } from '../../src/prop-types/oneOfTypes';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';
@@ -20,6 +21,10 @@ describe('oneOfTypesProp().optional', () => {
   describe('Vue 2.7', () => {
     expectAssignable<Vue2_7.PropOptions<Options | undefined>>(oneOfTypesProp<Options>(options).optional);
   });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<Options | undefined>>(oneOfTypesProp<Options>(options).optional);
+  });
 });
 
 describe('oneOfTypesProp().withDefault', () => {
@@ -34,6 +39,10 @@ describe('oneOfTypesProp().withDefault', () => {
   describe('Vue 2.7', () => {
     expectAssignable<Vue2_7.PropOptions<Options>>(oneOfTypesProp<Options>(options).withDefault('a'));
   });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<Options>>(oneOfTypesProp<Options>(options).withDefault('a'));
+  });
 });
 
 describe('oneOfTypesProp().required', () => {
@@ -47,5 +56,9 @@ describe('oneOfTypesProp().required', () => {
 
   describe('Vue 2.7', () => {
     expectAssignable<Vue2_7.PropOptions<Options>>(oneOfTypesProp<Options>(options).required);
+  });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<Options>>(oneOfTypesProp<Options>(options).required);
   });
 });

--- a/type-tests/prop-types/string.type.spec.ts
+++ b/type-tests/prop-types/string.type.spec.ts
@@ -1,6 +1,7 @@
 import { expectAssignable, expectNotAssignable, expectType } from 'tsd-lite';
 import type * as Vue2_6 from 'vue2-6/types/options';
 import type * as Vue2_7 from 'vue2-7/types/options';
+import type * as Vue3 from '@vue/runtime-core/dist/runtime-core';
 import { stringProp } from '../../src/prop-types/string';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';
@@ -29,6 +30,13 @@ describe('stringProp().optional', () => {
     expectNotAssignable<Vue2_7.PropOptions<string>>(stringProp().optional);
     expectNotAssignable<Vue2_7.PropOptions<Foo>>(stringProp<Foo>().optional);
   });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<string | undefined>>(stringProp().optional);
+    expectAssignable<Vue3.Prop<Foo | undefined>>(stringProp<Foo>().optional);
+    expectNotAssignable<Vue3.Prop<string>>(stringProp().optional);
+    expectNotAssignable<Vue3.Prop<Foo>>(stringProp<Foo>().optional);
+  });
 });
 
 describe('stringProp().withDefault', () => {
@@ -53,6 +61,13 @@ describe('stringProp().withDefault', () => {
     expectNotAssignable<Vue2_7.PropOptions<number>>(stringProp().withDefault('foo'));
     expectNotAssignable<Vue2_7.PropOptions<number>>(stringProp<Foo>().withDefault('a'));
   });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<string>>(stringProp().withDefault('foo'));
+    expectAssignable<Vue3.Prop<Foo>>(stringProp<Foo>().withDefault('a'));
+    expectNotAssignable<Vue3.Prop<number>>(stringProp().withDefault('foo'));
+    expectNotAssignable<Vue3.Prop<number>>(stringProp<Foo>().withDefault('a'));
+  });
 });
 
 describe('stringProp().required', () => {
@@ -76,5 +91,12 @@ describe('stringProp().required', () => {
     expectAssignable<Vue2_7.PropOptions<Foo>>(stringProp<Foo>().required);
     expectNotAssignable<Vue2_7.PropOptions<number>>(stringProp().required);
     expectNotAssignable<Vue2_7.PropOptions<number>>(stringProp<Foo>().required);
+  });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<string>>(stringProp().required);
+    expectAssignable<Vue3.Prop<Foo>>(stringProp<Foo>().required);
+    expectNotAssignable<Vue3.Prop<number>>(stringProp().required);
+    expectNotAssignable<Vue3.Prop<number>>(stringProp<Foo>().required);
   });
 });

--- a/type-tests/prop-types/string.type.spec.ts
+++ b/type-tests/prop-types/string.type.spec.ts
@@ -1,6 +1,6 @@
 import { expectAssignable, expectNotAssignable, expectType } from 'tsd-lite';
-import type * as Vue2 from 'vue/types/options';
-import type * as CompositionApi from '@vue/composition-api';
+import type * as Vue2_6 from 'vue2-6/types/options';
+import type * as Vue2_7 from 'vue2-7/types/options';
 import { stringProp } from '../../src/prop-types/string';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';
@@ -8,11 +8,11 @@ import type { Vue2ComponentWithProp } from '../utils';
 type Foo = 'a' | 'b' | 'c';
 
 describe('stringProp().optional', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<string | undefined>>(stringProp().optional);
-    expectAssignable<Vue2.PropOptions<Foo | undefined>>(stringProp<Foo>().optional);
-    expectNotAssignable<Vue2.PropOptions<string>>(stringProp().optional);
-    expectNotAssignable<Vue2.PropOptions<Foo>>(stringProp<Foo>().optional);
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<string | undefined>>(stringProp().optional);
+    expectAssignable<Vue2_6.PropOptions<Foo | undefined>>(stringProp<Foo>().optional);
+    expectNotAssignable<Vue2_6.PropOptions<string>>(stringProp().optional);
+    expectNotAssignable<Vue2_6.PropOptions<Foo>>(stringProp<Foo>().optional);
 
     expectType<Vue2ComponentWithProp<string | undefined>>(
       createVue2Component(stringProp().optional),
@@ -23,20 +23,20 @@ describe('stringProp().optional', () => {
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<string | undefined>>(stringProp().optional);
-    expectAssignable<CompositionApi.PropOptions<Foo | undefined>>(stringProp<Foo>().optional);
-    expectNotAssignable<CompositionApi.PropOptions<string>>(stringProp().optional);
-    expectNotAssignable<CompositionApi.PropOptions<Foo>>(stringProp<Foo>().optional);
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<string | undefined>>(stringProp().optional);
+    expectAssignable<Vue2_7.PropOptions<Foo | undefined>>(stringProp<Foo>().optional);
+    expectNotAssignable<Vue2_7.PropOptions<string>>(stringProp().optional);
+    expectNotAssignable<Vue2_7.PropOptions<Foo>>(stringProp<Foo>().optional);
   });
 });
 
 describe('stringProp().withDefault', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<string>>(stringProp().withDefault('foo'));
-    expectAssignable<Vue2.PropOptions<Foo>>(stringProp<Foo>().withDefault('a'));
-    expectNotAssignable<Vue2.PropOptions<number>>(stringProp().withDefault('foo'));
-    expectNotAssignable<Vue2.PropOptions<number>>(stringProp<Foo>().withDefault('a'));
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<string>>(stringProp().withDefault('foo'));
+    expectAssignable<Vue2_6.PropOptions<Foo>>(stringProp<Foo>().withDefault('a'));
+    expectNotAssignable<Vue2_6.PropOptions<number>>(stringProp().withDefault('foo'));
+    expectNotAssignable<Vue2_6.PropOptions<number>>(stringProp<Foo>().withDefault('a'));
 
     expectType<Vue2ComponentWithProp<string>>(
       createVue2Component(stringProp().withDefault('foo')),
@@ -47,20 +47,20 @@ describe('stringProp().withDefault', () => {
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<string>>(stringProp().withDefault('foo'));
-    expectAssignable<CompositionApi.PropOptions<Foo>>(stringProp<Foo>().withDefault('a'));
-    expectNotAssignable<CompositionApi.PropOptions<number>>(stringProp().withDefault('foo'));
-    expectNotAssignable<CompositionApi.PropOptions<number>>(stringProp<Foo>().withDefault('a'));
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<string>>(stringProp().withDefault('foo'));
+    expectAssignable<Vue2_7.PropOptions<Foo>>(stringProp<Foo>().withDefault('a'));
+    expectNotAssignable<Vue2_7.PropOptions<number>>(stringProp().withDefault('foo'));
+    expectNotAssignable<Vue2_7.PropOptions<number>>(stringProp<Foo>().withDefault('a'));
   });
 });
 
 describe('stringProp().required', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<string>>(stringProp().required);
-    expectAssignable<Vue2.PropOptions<Foo>>(stringProp<Foo>().required);
-    expectNotAssignable<Vue2.PropOptions<number>>(stringProp().required);
-    expectNotAssignable<Vue2.PropOptions<number>>(stringProp<Foo>().required);
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<string>>(stringProp().required);
+    expectAssignable<Vue2_6.PropOptions<Foo>>(stringProp<Foo>().required);
+    expectNotAssignable<Vue2_6.PropOptions<number>>(stringProp().required);
+    expectNotAssignable<Vue2_6.PropOptions<number>>(stringProp<Foo>().required);
 
     expectType<Vue2ComponentWithProp<string>>(
       createVue2Component(stringProp().required),
@@ -71,10 +71,10 @@ describe('stringProp().required', () => {
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<string>>(stringProp().required);
-    expectAssignable<CompositionApi.PropOptions<Foo>>(stringProp<Foo>().required);
-    expectNotAssignable<CompositionApi.PropOptions<number>>(stringProp().required);
-    expectNotAssignable<CompositionApi.PropOptions<number>>(stringProp<Foo>().required);
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<string>>(stringProp().required);
+    expectAssignable<Vue2_7.PropOptions<Foo>>(stringProp<Foo>().required);
+    expectNotAssignable<Vue2_7.PropOptions<number>>(stringProp().required);
+    expectNotAssignable<Vue2_7.PropOptions<number>>(stringProp<Foo>().required);
   });
 });

--- a/type-tests/prop-types/symbol.type.spec.ts
+++ b/type-tests/prop-types/symbol.type.spec.ts
@@ -1,54 +1,54 @@
 import { expectAssignable, expectNotAssignable, expectType } from 'tsd-lite';
-import type * as Vue2 from 'vue/types/options';
-import type * as CompositionApi from '@vue/composition-api';
+import type * as Vue2_6 from 'vue2-6/types/options';
+import type * as Vue2_7 from 'vue2-7/types/options';
 import { symbolProp } from '../../src/prop-types/symbol';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';
 
 describe('symbolProp().optional', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<symbol | undefined>>(symbolProp().optional);
-    expectNotAssignable<Vue2.PropOptions<symbol>>(symbolProp().optional);
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<symbol | undefined>>(symbolProp().optional);
+    expectNotAssignable<Vue2_6.PropOptions<symbol>>(symbolProp().optional);
 
     expectType<Vue2ComponentWithProp<symbol | undefined>>(
       createVue2Component(symbolProp().optional),
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<symbol | undefined>>(symbolProp().optional);
-    expectNotAssignable<CompositionApi.PropOptions<symbol>>(symbolProp().optional);
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<symbol | undefined>>(symbolProp().optional);
+    expectNotAssignable<Vue2_7.PropOptions<symbol>>(symbolProp().optional);
   });
 });
 
 describe('symbolProp().withDefault', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<symbol>>(symbolProp().withDefault(Symbol.for('foo')));
-    expectNotAssignable<Vue2.PropOptions<string>>(symbolProp().withDefault(Symbol.for('foo')));
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<symbol>>(symbolProp().withDefault(Symbol.for('foo')));
+    expectNotAssignable<Vue2_6.PropOptions<string>>(symbolProp().withDefault(Symbol.for('foo')));
 
     expectType<Vue2ComponentWithProp<symbol>>(
       createVue2Component(symbolProp().withDefault(Symbol.for('foo'))),
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<symbol>>(symbolProp().withDefault(Symbol.for('foo')));
-    expectNotAssignable<CompositionApi.PropOptions<string>>(symbolProp().withDefault(Symbol.for('foo')));
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<symbol>>(symbolProp().withDefault(Symbol.for('foo')));
+    expectNotAssignable<Vue2_7.PropOptions<string>>(symbolProp().withDefault(Symbol.for('foo')));
   });
 });
 
 describe('symbolProp().required', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<symbol>>(symbolProp().required);
-    expectNotAssignable<Vue2.PropOptions<string>>(symbolProp().required);
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<symbol>>(symbolProp().required);
+    expectNotAssignable<Vue2_6.PropOptions<string>>(symbolProp().required);
 
     expectType<Vue2ComponentWithProp<symbol>>(
       createVue2Component(symbolProp().required),
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<symbol>>(symbolProp().required);
-    expectNotAssignable<CompositionApi.PropOptions<string>>(symbolProp().required);
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<symbol>>(symbolProp().required);
+    expectNotAssignable<Vue2_7.PropOptions<string>>(symbolProp().required);
   });
 });

--- a/type-tests/prop-types/symbol.type.spec.ts
+++ b/type-tests/prop-types/symbol.type.spec.ts
@@ -1,6 +1,7 @@
 import { expectAssignable, expectNotAssignable, expectType } from 'tsd-lite';
 import type * as Vue2_6 from 'vue2-6/types/options';
 import type * as Vue2_7 from 'vue2-7/types/options';
+import type * as Vue3 from '@vue/runtime-core/dist/runtime-core';
 import { symbolProp } from '../../src/prop-types/symbol';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';
@@ -19,6 +20,11 @@ describe('symbolProp().optional', () => {
     expectAssignable<Vue2_7.PropOptions<symbol | undefined>>(symbolProp().optional);
     expectNotAssignable<Vue2_7.PropOptions<symbol>>(symbolProp().optional);
   });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<symbol | undefined>>(symbolProp().optional);
+    expectNotAssignable<Vue3.Prop<symbol>>(symbolProp().optional);
+  });
 });
 
 describe('symbolProp().withDefault', () => {
@@ -35,6 +41,11 @@ describe('symbolProp().withDefault', () => {
     expectAssignable<Vue2_7.PropOptions<symbol>>(symbolProp().withDefault(Symbol.for('foo')));
     expectNotAssignable<Vue2_7.PropOptions<string>>(symbolProp().withDefault(Symbol.for('foo')));
   });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<symbol>>(symbolProp().withDefault(Symbol.for('foo')));
+    expectNotAssignable<Vue3.Prop<string>>(symbolProp().withDefault(Symbol.for('foo')));
+  });
 });
 
 describe('symbolProp().required', () => {
@@ -50,5 +61,10 @@ describe('symbolProp().required', () => {
   describe('Vue 2.7', () => {
     expectAssignable<Vue2_7.PropOptions<symbol>>(symbolProp().required);
     expectNotAssignable<Vue2_7.PropOptions<string>>(symbolProp().required);
+  });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<symbol>>(symbolProp().required);
+    expectNotAssignable<Vue3.Prop<string>>(symbolProp().required);
   });
 });

--- a/type-tests/prop-types/vueComponent.type.spec.ts
+++ b/type-tests/prop-types/vueComponent.type.spec.ts
@@ -1,6 +1,7 @@
 import { expectAssignable, expectNotAssignable, expectType } from 'tsd-lite';
 import type * as Vue2_6 from 'vue2-6/types/options';
 import type * as Vue2_7 from 'vue2-7/types/options';
+import type * as Vue3 from '@vue/runtime-core/dist/runtime-core';
 import { vueComponentProp } from '../../src/prop-types/vueComponent';
 import type { VueComponent } from '../../src/prop-types/vueComponent';
 import { createVue2Component } from '../utils';
@@ -20,6 +21,11 @@ describe('vueComponentProp().optional', () => {
     expectAssignable<Vue2_7.PropOptions<VueComponent | undefined>>(vueComponentProp().optional);
     expectNotAssignable<Vue2_7.PropOptions<VueComponent>>(vueComponentProp().optional);
   });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<VueComponent | undefined>>(vueComponentProp().optional);
+    expectNotAssignable<Vue3.Prop<VueComponent>>(vueComponentProp().optional);
+  });
 });
 
 describe('vueComponentProp().withDefault', () => {
@@ -36,6 +42,11 @@ describe('vueComponentProp().withDefault', () => {
     expectAssignable<Vue2_7.PropOptions<VueComponent>>(vueComponentProp().withDefault('foo'));
     expectNotAssignable<Vue2_7.PropOptions<string>>(vueComponentProp().withDefault('foo'));
   });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<VueComponent>>(vueComponentProp().withDefault('foo'));
+    expectNotAssignable<Vue3.Prop<string>>(vueComponentProp().withDefault('foo'));
+  });
 });
 
 describe('vueComponentProp().required', () => {
@@ -51,5 +62,10 @@ describe('vueComponentProp().required', () => {
   describe('Vue 2.7', () => {
     expectAssignable<Vue2_7.PropOptions<VueComponent>>(vueComponentProp().required);
     expectNotAssignable<Vue2_7.PropOptions<string>>(vueComponentProp().required);
+  });
+
+  describe('Vue 3', () => {
+    expectAssignable<Vue3.Prop<VueComponent>>(vueComponentProp().required);
+    expectNotAssignable<Vue3.Prop<string>>(vueComponentProp().required);
   });
 });

--- a/type-tests/prop-types/vueComponent.type.spec.ts
+++ b/type-tests/prop-types/vueComponent.type.spec.ts
@@ -1,55 +1,55 @@
 import { expectAssignable, expectNotAssignable, expectType } from 'tsd-lite';
-import type * as Vue2 from 'vue/types/options';
-import type * as CompositionApi from '@vue/composition-api';
+import type * as Vue2_6 from 'vue2-6/types/options';
+import type * as Vue2_7 from 'vue2-7/types/options';
 import { vueComponentProp } from '../../src/prop-types/vueComponent';
 import type { VueComponent } from '../../src/prop-types/vueComponent';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';
 
 describe('vueComponentProp().optional', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<VueComponent | undefined>>(vueComponentProp().optional);
-    expectNotAssignable<Vue2.PropOptions<VueComponent>>(vueComponentProp().optional);
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<VueComponent | undefined>>(vueComponentProp().optional);
+    expectNotAssignable<Vue2_6.PropOptions<VueComponent>>(vueComponentProp().optional);
 
     expectType<Vue2ComponentWithProp<VueComponent | undefined>>(
       createVue2Component(vueComponentProp().optional),
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<VueComponent | undefined>>(vueComponentProp().optional);
-    expectNotAssignable<CompositionApi.PropOptions<VueComponent>>(vueComponentProp().optional);
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<VueComponent | undefined>>(vueComponentProp().optional);
+    expectNotAssignable<Vue2_7.PropOptions<VueComponent>>(vueComponentProp().optional);
   });
 });
 
 describe('vueComponentProp().withDefault', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<VueComponent>>(vueComponentProp().withDefault('foo'));
-    expectNotAssignable<Vue2.PropOptions<string>>(vueComponentProp().withDefault('foo'));
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<VueComponent>>(vueComponentProp().withDefault('foo'));
+    expectNotAssignable<Vue2_6.PropOptions<string>>(vueComponentProp().withDefault('foo'));
 
     expectType<Vue2ComponentWithProp<VueComponent>>(
       createVue2Component(vueComponentProp().withDefault('foo')),
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<VueComponent>>(vueComponentProp().withDefault('foo'));
-    expectNotAssignable<CompositionApi.PropOptions<string>>(vueComponentProp().withDefault('foo'));
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<VueComponent>>(vueComponentProp().withDefault('foo'));
+    expectNotAssignable<Vue2_7.PropOptions<string>>(vueComponentProp().withDefault('foo'));
   });
 });
 
 describe('vueComponentProp().required', () => {
-  describe('Vue 2', () => {
-    expectAssignable<Vue2.PropOptions<VueComponent>>(vueComponentProp().required);
-    expectNotAssignable<Vue2.PropOptions<string>>(vueComponentProp().required);
+  describe('Vue 2.6', () => {
+    expectAssignable<Vue2_6.PropOptions<VueComponent>>(vueComponentProp().required);
+    expectNotAssignable<Vue2_6.PropOptions<string>>(vueComponentProp().required);
 
     expectType<Vue2ComponentWithProp<VueComponent>>(
       createVue2Component(vueComponentProp().required),
     );
   });
 
-  describe('Composition API', () => {
-    expectAssignable<CompositionApi.PropOptions<VueComponent>>(vueComponentProp().required);
-    expectNotAssignable<CompositionApi.PropOptions<string>>(vueComponentProp().required);
+  describe('Vue 2.7', () => {
+    expectAssignable<Vue2_7.PropOptions<VueComponent>>(vueComponentProp().required);
+    expectNotAssignable<Vue2_7.PropOptions<string>>(vueComponentProp().required);
   });
 });

--- a/type-tests/utils.ts
+++ b/type-tests/utils.ts
@@ -1,5 +1,5 @@
-import Vue from 'vue';
-import type { ExtendedVue } from 'vue/types/vue';
+import Vue from 'vue2-6';
+import type { ExtendedVue } from 'vue2-6/types/vue';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const createVue2Component = <T>(prop: T) => Vue.component('test', {


### PR DESCRIPTION
Install Vue 2.6, Vue 2.7 (replaces `@vue/composition-api`) and Vue 3 alongside each other and add type tests for each version.