### PR TITLE
Drop development support for Node v12

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        version: [12, 14, 16]
+        version: [14, 16, 18]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -38,7 +38,7 @@ jobs:
     name: Type test
     strategy:
       matrix:
-        version: [12, 14, 16]
+        version: [14, 16, 18]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Please follow these guidelines:
 
 ## Development setup
 
-Make sure that Node.js (at least version 12) is installed.  
+Make sure that Node.js (at least version 14) is installed.  
 Install all development dependencies with `npm install`.
 
 Run tests or type tests in watch mode:


### PR DESCRIPTION
Since the build output doesn't depend on any Node v14+ specific features, this is not a breaking change.