### PR TITLE
Allow generic type for `numberProp`

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ booleanProp().withDefault(false)
   // → prop type: boolean
 ```
 
-### `numberProp(validator?: Validator)`
+### `numberProp<T>(validator?: Validator)`
 
 Allows any number (validated at runtime and compile time).
 Type parameter `T` can be used to restrict the type at compile time with a union type. (Consider using [`oneOfProp`](#oneofproptallowedvalues-readonly-any-validator-validator) in this case.)

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ booleanProp().withDefault(false)
 ### `numberProp(validator?: Validator)`
 
 Allows any number (validated at runtime and compile time).
+Type parameter `T` can be used to restrict the type at compile time with a union type. (Consider using [`oneOfProp`](#oneofproptallowedvalues-readonly-any-validator-validator) in this case.)
 
 ```ts
 numberProp().optional
@@ -227,6 +228,17 @@ numberProp().required
   // → prop type: number
 numberProp().withDefault(3.1415)
   // → prop type: number
+
+type Foo = 1 | 2 | 3;
+
+numberProp<Foo>().optional
+  // → prop type: Foo | undefined
+numberProp<Foo>().nullable
+  // → prop type: Foo | null
+numberProp<Foo>().required
+  // → prop type: Foo
+numberProp<Foo>().withDefault(1)
+  // → prop type: Foo
 ```
 
 ### `integerProp(validator?: Validator)`

--- a/src/prop-types/number.ts
+++ b/src/prop-types/number.ts
@@ -1,11 +1,13 @@
-import type { PropOptionsGenerator } from '../types';
+import type { PropOptionsGenerator, PropType } from '../types';
 import { propOptionsGenerator } from '../util';
 import type { Validator } from '../validators';
 
 /**
  * Allows any number (validated at runtime and compile time).
  *
+ * Type parameter `T` can be used to restrict the type at compile time with a union type.
+ *
  * @param validator - Optional function for further runtime validation; should return `undefined` if valid, or an error string if invalid.
  */
-export const numberProp = (validator?: Validator): PropOptionsGenerator<number> =>
-  propOptionsGenerator(Number, validator);
+export const numberProp = <T extends number = number>(validator?: Validator): PropOptionsGenerator<T> =>
+  propOptionsGenerator(Number as unknown as PropType<T>, validator);

--- a/type-tests/prop-types/number.type.spec.ts
+++ b/type-tests/prop-types/number.type.spec.ts
@@ -6,6 +6,8 @@ import { numberProp } from '../../src/prop-types/number';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';
 
+type Foo = 1 | 2 | 3;
+
 describe('numberProp().optional', () => {
   describe('Vue 2.6', () => {
     expectAssignable<Vue2_6.PropOptions<number | undefined>>(numberProp().optional);
@@ -14,15 +16,21 @@ describe('numberProp().optional', () => {
     expectType<Vue2ComponentWithProp<number | undefined>>(
       createVue2Component(numberProp().optional),
     );
+
+    expectType<Vue2ComponentWithProp<Foo | undefined>>(
+      createVue2Component(numberProp<Foo>().optional),
+    );
   });
 
   describe('Vue 2.7', () => {
     expectAssignable<Vue2_7.PropOptions<number | undefined>>(numberProp().optional);
+    expectAssignable<Vue2_7.PropOptions<Foo | undefined>>(numberProp<Foo>().optional);
     expectNotAssignable<Vue2_7.PropOptions<number>>(numberProp().optional);
   });
 
   describe('Vue 3', () => {
     expectAssignable<Vue3.Prop<number | undefined>>(numberProp().optional);
+    expectAssignable<Vue3.Prop<Foo | undefined>>(numberProp<Foo>().optional);
     expectNotAssignable<Vue3.Prop<number>>(numberProp().optional);
   });
 });
@@ -30,62 +38,90 @@ describe('numberProp().optional', () => {
 describe('numberProp().nullable', () => {
   describe('Vue 2.6', () => {
     expectAssignable<Vue2_6.PropOptions<number | null>>(numberProp().nullable);
+    expectAssignable<Vue2_6.PropOptions<Foo | null>>(numberProp<Foo>().nullable);
     expectNotAssignable<Vue2_6.PropOptions<number>>(numberProp().nullable);
+    expectNotAssignable<Vue2_6.PropOptions<Foo>>(numberProp<Foo>().nullable);
 
     expectType<Vue2ComponentWithProp<number | null>>(
       createVue2Component(numberProp().nullable),
+    );
+
+    expectType<Vue2ComponentWithProp<Foo | null>>(
+      createVue2Component(numberProp<Foo>().nullable),
     );
   });
 
   describe('Vue 2.7', () => {
     expectAssignable<Vue2_7.PropOptions<number | null>>(numberProp().nullable);
+    expectAssignable<Vue2_7.PropOptions<Foo | null>>(numberProp<Foo>().nullable);
     expectNotAssignable<Vue2_7.PropOptions<number>>(numberProp().nullable);
   });
 
   describe('Vue 3', () => {
     expectAssignable<Vue3.Prop<number | null>>(numberProp().nullable);
+    expectAssignable<Vue3.Prop<Foo | null>>(numberProp<Foo>().nullable);
     expectNotAssignable<Vue3.Prop<number>>(numberProp().nullable);
+    expectNotAssignable<Vue3.Prop<Foo>>(numberProp<Foo>().nullable);
   });
 });
 
 describe('numberProp().withDefault', () => {
   describe('Vue 2.6', () => {
     expectAssignable<Vue2_6.PropOptions<number>>(numberProp().withDefault(27));
+    expectAssignable<Vue2_6.PropOptions<Foo>>(numberProp<Foo>().withDefault(1));
     expectNotAssignable<Vue2_6.PropOptions<string>>(numberProp().withDefault(27));
 
     expectType<Vue2ComponentWithProp<number>>(
       createVue2Component(numberProp().withDefault(27)),
     );
+
+    expectType<Vue2ComponentWithProp<Foo>>(
+      createVue2Component(numberProp<Foo>().withDefault(1)),
+    );
   });
 
   describe('Vue 2.7', () => {
     expectAssignable<Vue2_7.PropOptions<number>>(numberProp().withDefault(27));
+    expectAssignable<Vue2_7.PropOptions<Foo>>(numberProp<Foo>().withDefault(1));
     expectNotAssignable<Vue2_7.PropOptions<string>>(numberProp().withDefault(27));
+    expectNotAssignable<Vue2_7.PropOptions<string>>(numberProp<Foo>().withDefault(1));
   });
 
   describe('Vue 3', () => {
     expectAssignable<Vue3.Prop<number>>(numberProp().withDefault(27));
+    expectAssignable<Vue3.Prop<Foo>>(numberProp<Foo>().withDefault(1));
     expectNotAssignable<Vue3.Prop<string>>(numberProp().withDefault(27));
+    expectNotAssignable<Vue3.Prop<string>>(numberProp<Foo>().withDefault(1));
   });
 });
 
 describe('numberProp().required', () => {
   describe('Vue 2.6', () => {
     expectAssignable<Vue2_6.PropOptions<number>>(numberProp().required);
+    expectAssignable<Vue2_6.PropOptions<Foo>>(numberProp<Foo>().required);
     expectNotAssignable<Vue2_6.PropOptions<string>>(numberProp().required);
+    expectNotAssignable<Vue2_6.PropOptions<string>>(numberProp<Foo>().required);
 
     expectType<Vue2ComponentWithProp<number>>(
       createVue2Component(numberProp().required),
+    );
+
+    expectType<Vue2ComponentWithProp<Foo>>(
+      createVue2Component(numberProp<Foo>().required),
     );
   });
 
   describe('Vue 2.7', () => {
     expectAssignable<Vue2_7.PropOptions<number>>(numberProp().required);
+    expectAssignable<Vue2_7.PropOptions<Foo>>(numberProp<Foo>().required);
     expectNotAssignable<Vue2_7.PropOptions<string>>(numberProp().required);
+    expectNotAssignable<Vue2_7.PropOptions<string>>(numberProp<Foo>().required);
   });
 
   describe('Vue 3', () => {
     expectAssignable<Vue3.Prop<number>>(numberProp().required);
+    expectAssignable<Vue3.Prop<Foo>>(numberProp<Foo>().required);
     expectNotAssignable<Vue3.Prop<string>>(numberProp().required);
+    expectNotAssignable<Vue3.Prop<string>>(numberProp<Foo>().required);
   });
 });


### PR DESCRIPTION
Closes FloEdelmann/vue-ts-types#172