### PR TITLE
Enable `eslint-plugin-jest-formatting`

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -19,9 +19,6 @@ module.exports = {
     tsconfigRootDir: __dirname,
     project: ['./tsconfig.json'],
   },
-  plugins: [
-    '@typescript-eslint',
-  ],
   rules: {
     // Core ESLint rules
     'accessor-pairs': 'error',
@@ -138,8 +135,10 @@ module.exports = {
   overrides: [
     {
       files: ['tests/**'],
-      plugins: ['jest'],
-      extends: ['plugin:jest/recommended'],
+      extends: [
+        'plugin:jest/recommended',
+        'plugin:jest-formatting/recommended',
+      ],
       rules: {
         // additional Jest rules
         'jest/consistent-test-it': 'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@typescript-eslint/parser": "^5.45.0",
         "eslint": "^8.28.0",
         "eslint-plugin-jest": "^27.1.6",
+        "eslint-plugin-jest-formatting": "^3.1.0",
         "eslint-plugin-unicorn": "^45.0.1",
         "jest": "^29.3.1",
         "jest-extended": "^3.2.0",
@@ -2730,6 +2731,18 @@
         "jest": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-jest-formatting": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest-formatting/-/eslint-plugin-jest-formatting-3.1.0.tgz",
+      "integrity": "sha512-XyysraZ1JSgGbLSDxjj5HzKKh0glgWf+7CkqxbTqb7zEhW7X2WHo5SBQ8cGhnszKN+2Lj3/oevBlHNbHezoc/A==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=0.8.0"
       }
     },
     "node_modules/eslint-plugin-unicorn": {
@@ -8276,6 +8289,13 @@
       "requires": {
         "@typescript-eslint/utils": "^5.10.0"
       }
+    },
+    "eslint-plugin-jest-formatting": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest-formatting/-/eslint-plugin-jest-formatting-3.1.0.tgz",
+      "integrity": "sha512-XyysraZ1JSgGbLSDxjj5HzKKh0glgWf+7CkqxbTqb7zEhW7X2WHo5SBQ8cGhnszKN+2Lj3/oevBlHNbHezoc/A==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-unicorn": {
       "version": "45.0.1",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@typescript-eslint/parser": "^5.45.0",
     "eslint": "^8.28.0",
     "eslint-plugin-jest": "^27.1.6",
+    "eslint-plugin-jest-formatting": "^3.1.0",
     "eslint-plugin-unicorn": "^45.0.1",
     "jest": "^29.3.1",
     "jest-extended": "^3.2.0",


### PR DESCRIPTION
To ensure that test cases are always properly formatted.