### PR TITLE
Group typescript-eslint updates in dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,6 +9,10 @@ updates:
       interval: "daily"
     labels:
       - "dependencies"
+    groups:
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
See https://github.blog/changelog/2023-08-24-grouped-version-updates-for-dependabot-are-generally-available/