### PR TITLE
Remove Dependabot groups

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,10 +9,6 @@ updates:
       interval: 'daily'
     labels:
       - 'dependencies'
-    groups:
-      typescript-eslint:
-        patterns:
-          - '@typescript-eslint/*'
 
   - package-ecosystem: 'github-actions'
     directory: '/'


### PR DESCRIPTION
Since #519, we don't list `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` separately in `package.json`, only the single `typescript-eslint` dependency (see also <https://typescript-eslint.io/blog/announcing-typescript-eslint-v7/#switching-to-typescript-eslint>). Thus, grouping in Dependabot is no longer necessary.