### PR TITLE
Install lefthook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+lefthook-local.yaml

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -1,0 +1,39 @@
+pre-commit:
+  parallel: true
+  commands:
+    main-branch-check:
+      only:
+        - ref: 'main'
+      run: 'exit 1'
+      fail_text: 'Please switch to another branch before committing. Use `git switch -c <branch-name>`.'
+    prettier:
+      run: 'npx prettier {staged_files} --check --ignore-unknown'
+      fail_text: 'Please fix the formatting issues before committing. Use `npm run format`.'
+    eslint:
+      glob: '*.{mjs,ts}'
+      run: 'npx eslint {staged_files}'
+      fail_text: 'Please fix the ESLint issues before committing. Try `npx eslint --fix .`.'
+    markdownlint:
+      glob: '*.md'
+      run: 'npx markdownlint {staged_files}'
+      fail_text: 'Please fix the markdownlint issues before committing. Try `npx markdownlint --fix .`.'
+    build:
+      glob: 'src/**'
+      run: 'npm run build'
+      fail_text: 'Please fix the build issues before committing. Try `npm run build`.'
+    test:
+      glob: '{src,tests}/**'
+      run: 'npm run test'
+      fail_text: 'Please fix the test issues before committing. Try `npm run test:watch`.'
+    type-test:
+      glob: '{src,type-tests}/**'
+      run: 'npm run type-test'
+      fail_text: 'Please fix the type test issues before committing. Try `npm run type-test`.'
+output:
+  - 'summary'
+  - 'success'
+  - 'failure'
+  - 'execution'
+  - 'execution_out'
+  - 'execution_info'
+  - 'skips'

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "eslint-plugin-unicorn": "^52.0.0",
         "jest": "^29.7.0",
         "jest-extended": "^4.0.2",
+        "lefthook": "^1.6.8",
         "markdownlint-cli": "^0.39.0",
         "prettier": "3.2.5",
         "ts-jest": "^29.1.2",
@@ -4400,6 +4401,130 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/lefthook": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-1.6.8.tgz",
+      "integrity": "sha512-h+5S3FLhErIrVTz+uLaysS0kATlzCW8Wa1DUqpu0rYsimsEk/TrP9cMnTVd0UKq3Ks2ooq5pCUmnipJy5zl1VQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "lefthook": "bin/index.js"
+      },
+      "optionalDependencies": {
+        "lefthook-darwin-arm64": "1.6.8",
+        "lefthook-darwin-x64": "1.6.8",
+        "lefthook-freebsd-arm64": "1.6.8",
+        "lefthook-freebsd-x64": "1.6.8",
+        "lefthook-linux-arm64": "1.6.8",
+        "lefthook-linux-x64": "1.6.8",
+        "lefthook-windows-arm64": "1.6.8",
+        "lefthook-windows-x64": "1.6.8"
+      }
+    },
+    "node_modules/lefthook-darwin-arm64": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-1.6.8.tgz",
+      "integrity": "sha512-L7iZVANp92MsYHRlpOlItXWGS6QL0w1E6T5GO00SGVoVPClA+Tkt26BFPhLZKa3pMbSHEhGTHeBMWJZ2Un/TnQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-darwin-x64": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-1.6.8.tgz",
+      "integrity": "sha512-BhYwl1CBi0eKKfsD9Bd6a6wmmaLHaZEBS5PlGc0h8hRWxC+CmBZyR0VDqXli9yxmgraI6psehM+w1v7RkP5pSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-freebsd-arm64": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-1.6.8.tgz",
+      "integrity": "sha512-pr86NVKUOiK0MwW2UZRLiDlYLV8XaqxKWRltVut4W78Ywb0PNTb3k4LVeMwfXiNqEgD8gug9vE8aZY1U3D2HMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-freebsd-x64": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-1.6.8.tgz",
+      "integrity": "sha512-pyzYRCHf6jSWoZJG22kE7KFbHQ1B6sHcxXP9o/Y5H8T/sHUxO03GEtdrGwyijMP0EJYb1vMfVWYY5WbWfg6SPg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-linux-arm64": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-1.6.8.tgz",
+      "integrity": "sha512-1VsEnfxWhs8YLMUnlYdbLBLldJrqJi/G2Isrvx0KBBu/nILxMmNa5GIQo8uqeeufmi/WVc8g3xgJtPxSp3NXnw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-linux-x64": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-1.6.8.tgz",
+      "integrity": "sha512-0e4GSPBhJkngO4qAX5bqJLYTftrBfulLiwbsWX6hx4SWFY3kFpCLtAYD8zfvfQaAfwb9Ieut2XnqcE9mNfI9+Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-windows-arm64": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-1.6.8.tgz",
+      "integrity": "sha512-bVYRF4mBcT2T5/uN5pJpk9jqvik8JLtgRL+BxTKPshuVFO2nJczgdX1lWRnveGyz84DHwYgu+GwYl7PLjGU28A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/lefthook-windows-x64": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-1.6.8.tgz",
+      "integrity": "sha512-cT3ZopXAFyEsfkRf+wRwINBPWUMYi2Wba59BqN8JU/Tfuuv7Of2e51u+VTsHMR+8+JdEt3A8Kl20xw24E8ccAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/leven": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint-plugin-unicorn": "^52.0.0",
     "jest": "^29.7.0",
     "jest-extended": "^4.0.2",
+    "lefthook": "^1.6.8",
     "markdownlint-cli": "^0.39.0",
     "prettier": "3.2.5",
     "ts-jest": "^29.1.2",


### PR DESCRIPTION
See https://github.com/evilmartians/lefthook.

### Advantages over https://github.com/typicode/husky + https://github.com/lint-staged/lint-staged

- only one dependency instead of two
- lefthook runs commands in parallel (but maybe lint-staged does that, too?)
- lefthook is built with Go and thus is fast (but probably husky+lint-staged would be fast enough)
- single configuration file (`lefthook.yaml`) rather than `.husky` directory with individual file for each hook + `lint-staged` section in `package.json`