### PR TITLE
Add GitHub Actions badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@
 
 > Lightweight TypeScript-first [Vue prop type](https://vuejs.org/guide/components/props.html#prop-validation) definitions
 
-[![npm](https://img.shields.io/npm/v/vue-ts-types?color=red)](https://www.npmjs.com/package/vue-ts-types) [![GitHub](https://img.shields.io/github/package-json/v/FloEdelmann/vue-ts-types?color=blue&logo=github)](https://github.com/FloEdelmann/vue-ts-types)
+[![npm][badge-npm]][npm] [![GitHub][badge-github]][github] [![GitHub tests workflow][badge-actions]][actions]
+
+[npm]: https://www.npmjs.com/package/vue-ts-types
+[github]: https://github.com/FloEdelmann/vue-ts-types
+[actions]: https://github.com/FloEdelmann/vue-ts-types/actions/workflows/test.yaml?query=branch%253Amain
+
+[badge-npm]: https://img.shields.io/npm/v/vue-ts-types?logo=npm&logoColor=white&color=red
+[badge-github]: https://img.shields.io/github/package-json/v/FloEdelmann/vue-ts-types?logo=github&color=blue
+[badge-actions]: https://img.shields.io/github/actions/workflow/status/FloEdelmann/vue-ts-types/test.yaml?logo=github&label=Tests
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [npm]: https://www.npmjs.com/package/vue-ts-types
 [github]: https://github.com/FloEdelmann/vue-ts-types
 [actions]: https://github.com/FloEdelmann/vue-ts-types/actions/workflows/test.yaml?query=branch%3Amain
-
 [badge-npm]: https://img.shields.io/npm/v/vue-ts-types?logo=npm&logoColor=white&color=red
 [badge-github]: https://img.shields.io/github/package-json/v/FloEdelmann/vue-ts-types?logo=github&color=blue
 [badge-actions]: https://img.shields.io/github/actions/workflow/status/FloEdelmann/vue-ts-types/test.yaml?logo=github&label=Tests

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [npm]: https://www.npmjs.com/package/vue-ts-types
 [github]: https://github.com/FloEdelmann/vue-ts-types
-[actions]: https://github.com/FloEdelmann/vue-ts-types/actions/workflows/test.yaml?query=branch%253Amain
+[actions]: https://github.com/FloEdelmann/vue-ts-types/actions/workflows/test.yaml?query=branch%3Amain
 
 [badge-npm]: https://img.shields.io/npm/v/vue-ts-types?logo=npm&logoColor=white&color=red
 [badge-github]: https://img.shields.io/github/package-json/v/FloEdelmann/vue-ts-types?logo=github&color=blue


### PR DESCRIPTION
1. Add GitHub Actions badge, linked to https://github.com/FloEdelmann/vue-ts-types/actions/workflows/test.yaml?query=branch%3Amain
2. Add icon to npm badge, so all badges have links
3. Use [reference-style Markdown links](https://www.markdownguide.org/basic-syntax/#reference-style-links) for badge links and images, to make the Markdown more readable