### PR TITLE
Upgrade TSTyche

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,21 +6,21 @@ Please follow these guidelines:
 
 ## Development setup
 
-Make sure that Node.js (at least version 14) is installed.  
+Make sure that Node.js (at least version 16) is installed.  
 Install all development dependencies with `npm install`.
 
-Run tests:
+Run tests and type tests:
 
 ```bash
 npm run test
-# or in watch mode
-npm run test:watch
+npm run type-test
 ```
 
-And type tests:
+Or in watch mode:
 
 ```bash
-npm run type-test
+npm run test:watch
+npm run type-test:watch
 ```
 
 Before you commit, run all following commands to ensure that all tests pass:

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "prettier": "3.3.0",
         "ts-jest": "^29.1.4",
         "ts-node": "^10.9.2",
-        "tstyche": "^1.1.0",
+        "tstyche": "^2.0.0-rc.1",
         "typescript": "^5.4.5",
         "typescript-eslint": "^7.12.0",
         "vue": "^3.4.27",
@@ -6107,15 +6107,15 @@
       }
     },
     "node_modules/tstyche": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/tstyche/-/tstyche-1.1.0.tgz",
-      "integrity": "sha512-ZvDeScrBJf6053bdOkGUtnfDn7414XjmjGWrDntQfSmtPvxv9HVJ+03GFK2O46hfoAI9L5Q22uw6xy5ZTBdPGg==",
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/tstyche/-/tstyche-2.0.0-rc.1.tgz",
+      "integrity": "sha512-eIttRzrj0jjQDMGFacepH6liYhlAKCZXB4DtSqptF0tftt9hF+woGeQhn7aeg7glwL4+xIG6eO3GQ1AMic3FHQ==",
       "dev": true,
       "bin": {
         "tstyche": "build/bin.js"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.14"
       },
       "funding": {
         "url": "https://github.com/tstyche/tstyche?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "lint:prettier": "prettier . --check",
     "test": "jest",
     "test:watch": "jest --watch",
-    "type-test": "tstyche"
+    "type-test": "tstyche",
+    "type-test:watch": "tstyche --watch"
   },
   "devDependencies": {
     "@eslint/js": "^9.4.0",
@@ -58,7 +59,7 @@
     "prettier": "3.3.0",
     "ts-jest": "^29.1.4",
     "ts-node": "^10.9.2",
-    "tstyche": "^1.1.0",
+    "tstyche": "^2.0.0-rc.1",
     "typescript": "^5.4.5",
     "typescript-eslint": "^7.12.0",
     "vue": "^3.4.27",

--- a/type-tests/prop-types/any.type.spec.ts
+++ b/type-tests/prop-types/any.type.spec.ts
@@ -8,53 +8,53 @@ import type { Vue2ComponentWithProp } from '../utils';
 
 describe('anyProp().optional', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions>().type.toBeAssignable(anyProp().optional);
-    expect<Vue2_6.PropOptions<number>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions>().type.toBeAssignableWith(anyProp().optional);
+    expect<Vue2_6.PropOptions<number>>().type.toBeAssignableWith(
       anyProp().optional,
     );
-    expect<Vue2_6.PropOptions<string>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<string>>().type.toBeAssignableWith(
       anyProp().optional,
     );
-    expect<Vue2_6.PropOptions<string | undefined>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<string | undefined>>().type.toBeAssignableWith(
       anyProp<string>().optional,
     );
-    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignableWith(
       anyProp<string>().optional,
     );
 
-    expect(createVue2Component(anyProp().optional)).type.toEqual<
+    expect(createVue2Component(anyProp().optional)).type.toBe<
       Vue2ComponentWithProp<any>
     >();
 
-    expect(createVue2Component(anyProp<string>().optional)).type.toEqual<
+    expect(createVue2Component(anyProp<string>().optional)).type.toBe<
       Vue2ComponentWithProp<string | undefined>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions>().type.toBeAssignable(anyProp().optional);
-    expect<Vue2_7.PropOptions<number>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions>().type.toBeAssignableWith(anyProp().optional);
+    expect<Vue2_7.PropOptions<number>>().type.toBeAssignableWith(
       anyProp().optional,
     );
-    expect<Vue2_7.PropOptions<string>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<string>>().type.toBeAssignableWith(
       anyProp().optional,
     );
-    expect<Vue2_7.PropOptions<string | undefined>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<string | undefined>>().type.toBeAssignableWith(
       anyProp<string>().optional,
     );
-    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignableWith(
       anyProp<string>().optional,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<any>>().type.toBeAssignable(anyProp().optional);
-    expect<Vue3.Prop<number>>().type.toBeAssignable(anyProp().optional);
-    expect<Vue3.Prop<string>>().type.toBeAssignable(anyProp().optional);
-    expect<Vue3.Prop<string | undefined>>().type.toBeAssignable(
+    expect<Vue3.Prop<any>>().type.toBeAssignableWith(anyProp().optional);
+    expect<Vue3.Prop<number>>().type.toBeAssignableWith(anyProp().optional);
+    expect<Vue3.Prop<string>>().type.toBeAssignableWith(anyProp().optional);
+    expect<Vue3.Prop<string | undefined>>().type.toBeAssignableWith(
       anyProp<string>().optional,
     );
-    expect<Vue3.Prop<string>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<string>>().type.not.toBeAssignableWith(
       anyProp<string>().optional,
     );
   });
@@ -62,53 +62,53 @@ describe('anyProp().optional', () => {
 
 describe('anyProp().nullable', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions>().type.toBeAssignable(anyProp().nullable);
-    expect<Vue2_6.PropOptions<number>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions>().type.toBeAssignableWith(anyProp().nullable);
+    expect<Vue2_6.PropOptions<number>>().type.toBeAssignableWith(
       anyProp().nullable,
     );
-    expect<Vue2_6.PropOptions<string>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<string>>().type.toBeAssignableWith(
       anyProp().nullable,
     );
-    expect<Vue2_6.PropOptions<string | null>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<string | null>>().type.toBeAssignableWith(
       anyProp<string>().nullable,
     );
-    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignableWith(
       anyProp<string>().nullable,
     );
 
-    expect(createVue2Component(anyProp().nullable)).type.toEqual<
+    expect(createVue2Component(anyProp().nullable)).type.toBe<
       Vue2ComponentWithProp<any>
     >();
 
-    expect(createVue2Component(anyProp<string>().nullable)).type.toEqual<
+    expect(createVue2Component(anyProp<string>().nullable)).type.toBe<
       Vue2ComponentWithProp<string | null>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions>().type.toBeAssignable(anyProp().nullable);
-    expect<Vue2_7.PropOptions<number>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions>().type.toBeAssignableWith(anyProp().nullable);
+    expect<Vue2_7.PropOptions<number>>().type.toBeAssignableWith(
       anyProp().nullable,
     );
-    expect<Vue2_7.PropOptions<string>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<string>>().type.toBeAssignableWith(
       anyProp().nullable,
     );
-    expect<Vue2_7.PropOptions<string | null>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<string | null>>().type.toBeAssignableWith(
       anyProp<string>().nullable,
     );
-    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignableWith(
       anyProp<string>().nullable,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<any>>().type.toBeAssignable(anyProp().nullable);
-    expect<Vue3.Prop<number>>().type.toBeAssignable(anyProp().nullable);
-    expect<Vue3.Prop<string>>().type.toBeAssignable(anyProp().nullable);
-    expect<Vue3.Prop<string | null>>().type.toBeAssignable(
+    expect<Vue3.Prop<any>>().type.toBeAssignableWith(anyProp().nullable);
+    expect<Vue3.Prop<number>>().type.toBeAssignableWith(anyProp().nullable);
+    expect<Vue3.Prop<string>>().type.toBeAssignableWith(anyProp().nullable);
+    expect<Vue3.Prop<string | null>>().type.toBeAssignableWith(
       anyProp<string>().nullable,
     );
-    expect<Vue3.Prop<string>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<string>>().type.not.toBeAssignableWith(
       anyProp<string>().nullable,
     );
   });
@@ -116,61 +116,63 @@ describe('anyProp().nullable', () => {
 
 describe('anyProp().withDefault', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions>().type.toBeAssignableWith(
       anyProp().withDefault('foo'),
     );
-    expect<Vue2_6.PropOptions<string>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<string>>().type.toBeAssignableWith(
       anyProp().withDefault('foo'),
     );
-    expect<Vue2_6.PropOptions<number>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<number>>().type.toBeAssignableWith(
       anyProp().withDefault('foo'),
     );
-    expect<Vue2_6.PropOptions<string>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<string>>().type.toBeAssignableWith(
       anyProp<string>().withDefault('foo'),
     );
-    expect<Vue2_6.PropOptions<number>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<number>>().type.not.toBeAssignableWith(
       anyProp<string>().withDefault('foo'),
     );
 
-    expect(createVue2Component(anyProp().withDefault('foo'))).type.toEqual<
+    expect(createVue2Component(anyProp().withDefault('foo'))).type.toBe<
       Vue2ComponentWithProp<any>
     >();
 
-    expect(
-      createVue2Component(anyProp<string>().withDefault('foo')),
-    ).type.toEqual<Vue2ComponentWithProp<string>>();
+    expect(createVue2Component(anyProp<string>().withDefault('foo'))).type.toBe<
+      Vue2ComponentWithProp<string>
+    >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions>().type.toBeAssignableWith(
       anyProp().withDefault('foo'),
     );
-    expect<Vue2_7.PropOptions<string>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<string>>().type.toBeAssignableWith(
       anyProp().withDefault('foo'),
     );
-    expect<Vue2_7.PropOptions<number>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<number>>().type.toBeAssignableWith(
       anyProp().withDefault('foo'),
     );
-    expect<Vue2_7.PropOptions<string>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<string>>().type.toBeAssignableWith(
       anyProp<string>().withDefault('foo'),
     );
-    expect<Vue2_7.PropOptions<number>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<number>>().type.not.toBeAssignableWith(
       anyProp<string>().withDefault('foo'),
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<any>>().type.toBeAssignable(anyProp().withDefault('foo'));
-    expect<Vue3.Prop<string>>().type.toBeAssignable(
+    expect<Vue3.Prop<any>>().type.toBeAssignableWith(
       anyProp().withDefault('foo'),
     );
-    expect<Vue3.Prop<number>>().type.toBeAssignable(
+    expect<Vue3.Prop<string>>().type.toBeAssignableWith(
       anyProp().withDefault('foo'),
     );
-    expect<Vue3.Prop<string>>().type.toBeAssignable(
+    expect<Vue3.Prop<number>>().type.toBeAssignableWith(
+      anyProp().withDefault('foo'),
+    );
+    expect<Vue3.Prop<string>>().type.toBeAssignableWith(
       anyProp<string>().withDefault('foo'),
     );
-    expect<Vue3.Prop<number>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<number>>().type.not.toBeAssignableWith(
       anyProp<string>().withDefault('foo'),
     );
   });
@@ -178,44 +180,46 @@ describe('anyProp().withDefault', () => {
 
 describe('anyProp().required', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions>().type.toBeAssignable(anyProp().required);
-    expect<Vue2_6.PropOptions<string>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions>().type.toBeAssignableWith(anyProp().required);
+    expect<Vue2_6.PropOptions<string>>().type.toBeAssignableWith(
       anyProp().required,
     );
-    expect<Vue2_6.PropOptions<string>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<string>>().type.toBeAssignableWith(
       anyProp<string>().required,
     );
-    expect<Vue2_6.PropOptions<number>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<number>>().type.not.toBeAssignableWith(
       anyProp<string>().required,
     );
 
-    expect(createVue2Component(anyProp().required)).type.toEqual<
+    expect(createVue2Component(anyProp().required)).type.toBe<
       Vue2ComponentWithProp<any>
     >();
 
-    expect(createVue2Component(anyProp<string>().required)).type.toEqual<
+    expect(createVue2Component(anyProp<string>().required)).type.toBe<
       Vue2ComponentWithProp<string>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions>().type.toBeAssignable(anyProp().required);
-    expect<Vue2_7.PropOptions<string>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions>().type.toBeAssignableWith(anyProp().required);
+    expect<Vue2_7.PropOptions<string>>().type.toBeAssignableWith(
       anyProp().required,
     );
-    expect<Vue2_7.PropOptions<string>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<string>>().type.toBeAssignableWith(
       anyProp<string>().required,
     );
-    expect<Vue2_7.PropOptions<number>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<number>>().type.not.toBeAssignableWith(
       anyProp<string>().required,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<any>>().type.toBeAssignable(anyProp().required);
-    expect<Vue3.Prop<string>>().type.toBeAssignable(anyProp().required);
-    expect<Vue3.Prop<string>>().type.toBeAssignable(anyProp<string>().required);
-    expect<Vue3.Prop<number>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<any>>().type.toBeAssignableWith(anyProp().required);
+    expect<Vue3.Prop<string>>().type.toBeAssignableWith(anyProp().required);
+    expect<Vue3.Prop<string>>().type.toBeAssignableWith(
+      anyProp<string>().required,
+    );
+    expect<Vue3.Prop<number>>().type.not.toBeAssignableWith(
       anyProp<string>().required,
     );
   });

--- a/type-tests/prop-types/array.type.spec.ts
+++ b/type-tests/prop-types/array.type.spec.ts
@@ -8,54 +8,54 @@ import type { Vue2ComponentWithProp } from '../utils';
 
 describe('arrayProp().optional', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<unknown[] | undefined>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<unknown[] | undefined>>().type.toBeAssignableWith(
       arrayProp().optional,
     );
-    expect<Vue2_6.PropOptions<string[] | undefined>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<string[] | undefined>>().type.toBeAssignableWith(
       arrayProp<string>().optional,
     );
-    expect<Vue2_6.PropOptions<unknown[]>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<unknown[]>>().type.not.toBeAssignableWith(
       arrayProp().optional,
     );
-    expect<Vue2_6.PropOptions<string[]>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<string[]>>().type.not.toBeAssignableWith(
       arrayProp<string>().optional,
     );
 
-    expect(createVue2Component(arrayProp().optional)).type.toEqual<
+    expect(createVue2Component(arrayProp().optional)).type.toBe<
       Vue2ComponentWithProp<unknown[] | undefined>
     >();
 
-    expect(createVue2Component(arrayProp<string>().optional)).type.toEqual<
+    expect(createVue2Component(arrayProp<string>().optional)).type.toBe<
       Vue2ComponentWithProp<string[] | undefined>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<unknown[] | undefined>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<unknown[] | undefined>>().type.toBeAssignableWith(
       arrayProp().optional,
     );
-    expect<Vue2_7.PropOptions<string[] | undefined>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<string[] | undefined>>().type.toBeAssignableWith(
       arrayProp<string>().optional,
     );
-    expect<Vue2_7.PropOptions<unknown[]>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<unknown[]>>().type.not.toBeAssignableWith(
       arrayProp().optional,
     );
-    expect<Vue2_7.PropOptions<string[]>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<string[]>>().type.not.toBeAssignableWith(
       arrayProp<string>().optional,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<unknown[] | undefined>>().type.toBeAssignable(
+    expect<Vue3.Prop<unknown[] | undefined>>().type.toBeAssignableWith(
       arrayProp().optional,
     );
-    expect<Vue3.Prop<string[] | undefined>>().type.toBeAssignable(
+    expect<Vue3.Prop<string[] | undefined>>().type.toBeAssignableWith(
       arrayProp<string>().optional,
     );
-    expect<Vue3.Prop<unknown[]>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<unknown[]>>().type.not.toBeAssignableWith(
       arrayProp().optional,
     );
-    expect<Vue3.Prop<string[]>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<string[]>>().type.not.toBeAssignableWith(
       arrayProp<string>().optional,
     );
   });
@@ -63,54 +63,54 @@ describe('arrayProp().optional', () => {
 
 describe('arrayProp().nullable', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<unknown[] | null>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<unknown[] | null>>().type.toBeAssignableWith(
       arrayProp().nullable,
     );
-    expect<Vue2_6.PropOptions<string[] | null>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<string[] | null>>().type.toBeAssignableWith(
       arrayProp<string>().nullable,
     );
-    expect<Vue2_6.PropOptions<unknown[]>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<unknown[]>>().type.not.toBeAssignableWith(
       arrayProp().nullable,
     );
-    expect<Vue2_6.PropOptions<string[]>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<string[]>>().type.not.toBeAssignableWith(
       arrayProp<string>().nullable,
     );
 
-    expect(createVue2Component(arrayProp().nullable)).type.toEqual<
+    expect(createVue2Component(arrayProp().nullable)).type.toBe<
       Vue2ComponentWithProp<unknown[] | null>
     >();
 
-    expect(createVue2Component(arrayProp<string>().nullable)).type.toEqual<
+    expect(createVue2Component(arrayProp<string>().nullable)).type.toBe<
       Vue2ComponentWithProp<string[] | null>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<unknown[] | null>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<unknown[] | null>>().type.toBeAssignableWith(
       arrayProp().nullable,
     );
-    expect<Vue2_7.PropOptions<string[] | null>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<string[] | null>>().type.toBeAssignableWith(
       arrayProp<string>().nullable,
     );
-    expect<Vue2_7.PropOptions<unknown[]>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<unknown[]>>().type.not.toBeAssignableWith(
       arrayProp().nullable,
     );
-    expect<Vue2_7.PropOptions<string[]>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<string[]>>().type.not.toBeAssignableWith(
       arrayProp<string>().nullable,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<unknown[] | null>>().type.toBeAssignable(
+    expect<Vue3.Prop<unknown[] | null>>().type.toBeAssignableWith(
       arrayProp().nullable,
     );
-    expect<Vue3.Prop<string[] | null>>().type.toBeAssignable(
+    expect<Vue3.Prop<string[] | null>>().type.toBeAssignableWith(
       arrayProp<string>().nullable,
     );
-    expect<Vue3.Prop<unknown[]>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<unknown[]>>().type.not.toBeAssignableWith(
       arrayProp().nullable,
     );
-    expect<Vue3.Prop<string[]>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<string[]>>().type.not.toBeAssignableWith(
       arrayProp<string>().nullable,
     );
   });
@@ -118,13 +118,13 @@ describe('arrayProp().nullable', () => {
 
 describe('arrayProp().withDefault', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<unknown[]>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<unknown[]>>().type.toBeAssignableWith(
       arrayProp().withDefault(() => ['foo', 'bar']),
     );
-    expect<Vue2_6.PropOptions<string[]>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<string[]>>().type.not.toBeAssignableWith(
       arrayProp().withDefault(() => ['foo', 'bar']),
     );
-    expect<Vue2_6.PropOptions<string[]>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<string[]>>().type.toBeAssignableWith(
       arrayProp<string>().withDefault(() => ['foo', 'bar']),
     );
 
@@ -132,29 +132,29 @@ describe('arrayProp().withDefault', () => {
       createVue2Component(
         arrayProp<string>().withDefault(() => ['foo', 'bar']),
       ),
-    ).type.toEqual<Vue2ComponentWithProp<string[]>>();
+    ).type.toBe<Vue2ComponentWithProp<string[]>>();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<unknown[]>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<unknown[]>>().type.toBeAssignableWith(
       arrayProp().withDefault(() => ['foo', 'bar']),
     );
-    expect<Vue2_7.PropOptions<string[]>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<string[]>>().type.not.toBeAssignableWith(
       arrayProp().withDefault(() => ['foo', 'bar']),
     );
-    expect<Vue2_7.PropOptions<string[]>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<string[]>>().type.toBeAssignableWith(
       arrayProp<string>().withDefault(() => ['foo', 'bar']),
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<unknown[]>>().type.toBeAssignable(
+    expect<Vue3.Prop<unknown[]>>().type.toBeAssignableWith(
       arrayProp().withDefault(() => ['foo', 'bar']),
     );
-    expect<Vue3.Prop<string[]>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<string[]>>().type.not.toBeAssignableWith(
       arrayProp().withDefault(() => ['foo', 'bar']),
     );
-    expect<Vue3.Prop<string[]>>().type.toBeAssignable(
+    expect<Vue3.Prop<string[]>>().type.toBeAssignableWith(
       arrayProp<string>().withDefault(() => ['foo', 'bar']),
     );
   });
@@ -162,43 +162,45 @@ describe('arrayProp().withDefault', () => {
 
 describe('arrayProp().required', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<unknown[]>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<unknown[]>>().type.toBeAssignableWith(
       arrayProp().required,
     );
-    expect<Vue2_6.PropOptions<string[]>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<string[]>>().type.toBeAssignableWith(
       arrayProp<string>().required,
     );
-    expect<Vue2_6.PropOptions<number[]>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<number[]>>().type.not.toBeAssignableWith(
       arrayProp<string>().required,
     );
 
-    expect(createVue2Component(arrayProp().required)).type.toEqual<
+    expect(createVue2Component(arrayProp().required)).type.toBe<
       Vue2ComponentWithProp<unknown[]>
     >();
 
-    expect(createVue2Component(arrayProp<string>().required)).type.toEqual<
+    expect(createVue2Component(arrayProp<string>().required)).type.toBe<
       Vue2ComponentWithProp<string[]>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<unknown[]>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<unknown[]>>().type.toBeAssignableWith(
       arrayProp().required,
     );
-    expect<Vue2_7.PropOptions<string[]>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<string[]>>().type.toBeAssignableWith(
       arrayProp<string>().required,
     );
-    expect<Vue2_7.PropOptions<number[]>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<number[]>>().type.not.toBeAssignableWith(
       arrayProp<string>().required,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<unknown[]>>().type.toBeAssignable(arrayProp().required);
-    expect<Vue3.Prop<string[]>>().type.toBeAssignable(
+    expect<Vue3.Prop<unknown[]>>().type.toBeAssignableWith(
+      arrayProp().required,
+    );
+    expect<Vue3.Prop<string[]>>().type.toBeAssignableWith(
       arrayProp<string>().required,
     );
-    expect<Vue3.Prop<number[]>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<number[]>>().type.not.toBeAssignableWith(
       arrayProp<string>().required,
     );
   });

--- a/type-tests/prop-types/boolean.type.spec.ts
+++ b/type-tests/prop-types/boolean.type.spec.ts
@@ -8,32 +8,32 @@ import type { Vue2ComponentWithProp } from '../utils';
 
 describe('booleanProp().optional', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<boolean | undefined>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<boolean | undefined>>().type.toBeAssignableWith(
       booleanProp().optional,
     );
-    expect<Vue2_6.PropOptions<boolean>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<boolean>>().type.not.toBeAssignableWith(
       booleanProp().optional,
     );
 
-    expect(createVue2Component(booleanProp().optional)).type.toEqual<
+    expect(createVue2Component(booleanProp().optional)).type.toBe<
       Vue2ComponentWithProp<boolean | undefined>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<boolean | undefined>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<boolean | undefined>>().type.toBeAssignableWith(
       booleanProp().optional,
     );
-    expect<Vue2_7.PropOptions<boolean>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<boolean>>().type.not.toBeAssignableWith(
       booleanProp().optional,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<boolean | undefined>>().type.toBeAssignable(
+    expect<Vue3.Prop<boolean | undefined>>().type.toBeAssignableWith(
       booleanProp().optional,
     );
-    expect<Vue3.Prop<boolean>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<boolean>>().type.not.toBeAssignableWith(
       booleanProp().optional,
     );
   });
@@ -41,32 +41,32 @@ describe('booleanProp().optional', () => {
 
 describe('booleanProp().nullable', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<boolean | null>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<boolean | null>>().type.toBeAssignableWith(
       booleanProp().nullable,
     );
-    expect<Vue2_6.PropOptions<boolean>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<boolean>>().type.not.toBeAssignableWith(
       booleanProp().nullable,
     );
 
-    expect(createVue2Component(booleanProp().nullable)).type.toEqual<
+    expect(createVue2Component(booleanProp().nullable)).type.toBe<
       Vue2ComponentWithProp<boolean | null>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<boolean | null>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<boolean | null>>().type.toBeAssignableWith(
       booleanProp().nullable,
     );
-    expect<Vue2_7.PropOptions<boolean>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<boolean>>().type.not.toBeAssignableWith(
       booleanProp().nullable,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<boolean | null>>().type.toBeAssignable(
+    expect<Vue3.Prop<boolean | null>>().type.toBeAssignableWith(
       booleanProp().nullable,
     );
-    expect<Vue3.Prop<boolean>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<boolean>>().type.not.toBeAssignableWith(
       booleanProp().nullable,
     );
   });
@@ -74,32 +74,32 @@ describe('booleanProp().nullable', () => {
 
 describe('booleanProp().withDefault(false)', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<boolean>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<boolean>>().type.toBeAssignableWith(
       booleanProp().withDefault(false),
     );
-    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignableWith(
       booleanProp().withDefault(false),
     );
 
-    expect(createVue2Component(booleanProp().withDefault(false))).type.toEqual<
+    expect(createVue2Component(booleanProp().withDefault(false))).type.toBe<
       Vue2ComponentWithProp<boolean>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<boolean>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<boolean>>().type.toBeAssignableWith(
       booleanProp().withDefault(false),
     );
-    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignableWith(
       booleanProp().withDefault(false),
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<boolean>>().type.toBeAssignable(
+    expect<Vue3.Prop<boolean>>().type.toBeAssignableWith(
       booleanProp().withDefault(false),
     );
-    expect<Vue3.Prop<string>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<string>>().type.not.toBeAssignableWith(
       booleanProp().withDefault(false),
     );
   });
@@ -107,29 +107,33 @@ describe('booleanProp().withDefault(false)', () => {
 
 describe('booleanProp().required', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<boolean>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<boolean>>().type.toBeAssignableWith(
       booleanProp().required,
     );
-    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignableWith(
       booleanProp().required,
     );
 
-    expect(createVue2Component(booleanProp().required)).type.toEqual<
+    expect(createVue2Component(booleanProp().required)).type.toBe<
       Vue2ComponentWithProp<boolean>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<boolean>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<boolean>>().type.toBeAssignableWith(
       booleanProp().required,
     );
-    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignableWith(
       booleanProp().required,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<boolean>>().type.toBeAssignable(booleanProp().required);
-    expect<Vue3.Prop<string>>().type.not.toBeAssignable(booleanProp().required);
+    expect<Vue3.Prop<boolean>>().type.toBeAssignableWith(
+      booleanProp().required,
+    );
+    expect<Vue3.Prop<string>>().type.not.toBeAssignableWith(
+      booleanProp().required,
+    );
   });
 });

--- a/type-tests/prop-types/function.type.spec.ts
+++ b/type-tests/prop-types/function.type.spec.ts
@@ -12,54 +12,54 @@ type MyCustomCallback = (parameter: string) => Promise<boolean>;
 
 describe('functionProp().optional', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<Function | undefined>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<Function | undefined>>().type.toBeAssignableWith(
       functionProp().optional,
     );
     expect<
       Vue2_6.PropOptions<MyCustomCallback | undefined>
-    >().type.toBeAssignable(functionProp<MyCustomCallback>().optional);
-    expect<Vue2_6.PropOptions<Function>>().type.not.toBeAssignable(
+    >().type.toBeAssignableWith(functionProp<MyCustomCallback>().optional);
+    expect<Vue2_6.PropOptions<Function>>().type.not.toBeAssignableWith(
       functionProp().optional,
     );
-    expect<Vue2_6.PropOptions<MyCustomCallback>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<MyCustomCallback>>().type.not.toBeAssignableWith(
       functionProp<MyCustomCallback>().optional,
     );
 
-    expect(createVue2Component(functionProp().optional)).type.toEqual<
+    expect(createVue2Component(functionProp().optional)).type.toBe<
       Vue2ComponentWithProp<Function | undefined>
     >();
 
     expect(
       createVue2Component(functionProp<MyCustomCallback>().optional),
-    ).type.toEqual<Vue2ComponentWithProp<MyCustomCallback | undefined>>();
+    ).type.toBe<Vue2ComponentWithProp<MyCustomCallback | undefined>>();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<Function | undefined>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<Function | undefined>>().type.toBeAssignableWith(
       functionProp().optional,
     );
     expect<
       Vue2_7.PropOptions<MyCustomCallback | undefined>
-    >().type.toBeAssignable(functionProp<MyCustomCallback>().optional);
-    expect<Vue2_7.PropOptions<Function>>().type.not.toBeAssignable(
+    >().type.toBeAssignableWith(functionProp<MyCustomCallback>().optional);
+    expect<Vue2_7.PropOptions<Function>>().type.not.toBeAssignableWith(
       functionProp().optional,
     );
-    expect<Vue2_7.PropOptions<MyCustomCallback>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<MyCustomCallback>>().type.not.toBeAssignableWith(
       functionProp<MyCustomCallback>().optional,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<Function | undefined>>().type.toBeAssignable(
+    expect<Vue3.Prop<Function | undefined>>().type.toBeAssignableWith(
       functionProp().optional,
     );
-    expect<Vue3.Prop<MyCustomCallback | undefined>>().type.toBeAssignable(
+    expect<Vue3.Prop<MyCustomCallback | undefined>>().type.toBeAssignableWith(
       functionProp<MyCustomCallback>().optional,
     );
-    expect<Vue3.Prop<Function>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<Function>>().type.not.toBeAssignableWith(
       functionProp().optional,
     );
-    expect<Vue3.Prop<MyCustomCallback>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<MyCustomCallback>>().type.not.toBeAssignableWith(
       functionProp<MyCustomCallback>().optional,
     );
   });
@@ -67,54 +67,54 @@ describe('functionProp().optional', () => {
 
 describe('functionProp().nullable', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<Function | null>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<Function | null>>().type.toBeAssignableWith(
       functionProp().nullable,
     );
-    expect<Vue2_6.PropOptions<MyCustomCallback | null>>().type.toBeAssignable(
-      functionProp<MyCustomCallback>().nullable,
-    );
-    expect<Vue2_6.PropOptions<Function>>().type.not.toBeAssignable(
+    expect<
+      Vue2_6.PropOptions<MyCustomCallback | null>
+    >().type.toBeAssignableWith(functionProp<MyCustomCallback>().nullable);
+    expect<Vue2_6.PropOptions<Function>>().type.not.toBeAssignableWith(
       functionProp().nullable,
     );
-    expect<Vue2_6.PropOptions<MyCustomCallback>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<MyCustomCallback>>().type.not.toBeAssignableWith(
       functionProp<MyCustomCallback>().nullable,
     );
 
-    expect(createVue2Component(functionProp().nullable)).type.toEqual<
+    expect(createVue2Component(functionProp().nullable)).type.toBe<
       Vue2ComponentWithProp<Function | null>
     >();
 
     expect(
       createVue2Component(functionProp<MyCustomCallback>().nullable),
-    ).type.toEqual<Vue2ComponentWithProp<MyCustomCallback | null>>();
+    ).type.toBe<Vue2ComponentWithProp<MyCustomCallback | null>>();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<Function | null>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<Function | null>>().type.toBeAssignableWith(
       functionProp().nullable,
     );
-    expect<Vue2_7.PropOptions<MyCustomCallback | null>>().type.toBeAssignable(
-      functionProp<MyCustomCallback>().nullable,
-    );
-    expect<Vue2_7.PropOptions<Function>>().type.not.toBeAssignable(
+    expect<
+      Vue2_7.PropOptions<MyCustomCallback | null>
+    >().type.toBeAssignableWith(functionProp<MyCustomCallback>().nullable);
+    expect<Vue2_7.PropOptions<Function>>().type.not.toBeAssignableWith(
       functionProp().nullable,
     );
-    expect<Vue2_7.PropOptions<MyCustomCallback>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<MyCustomCallback>>().type.not.toBeAssignableWith(
       functionProp<MyCustomCallback>().nullable,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<Function | null>>().type.toBeAssignable(
+    expect<Vue3.Prop<Function | null>>().type.toBeAssignableWith(
       functionProp().nullable,
     );
-    expect<Vue3.Prop<MyCustomCallback | null>>().type.toBeAssignable(
+    expect<Vue3.Prop<MyCustomCallback | null>>().type.toBeAssignableWith(
       functionProp<MyCustomCallback>().nullable,
     );
-    expect<Vue3.Prop<Function>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<Function>>().type.not.toBeAssignableWith(
       functionProp().nullable,
     );
-    expect<Vue3.Prop<MyCustomCallback>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<MyCustomCallback>>().type.not.toBeAssignableWith(
       functionProp<MyCustomCallback>().nullable,
     );
   });
@@ -122,43 +122,45 @@ describe('functionProp().nullable', () => {
 
 describe('functionProp().required', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<Function>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<Function>>().type.toBeAssignableWith(
       functionProp().required,
     );
-    expect<Vue2_6.PropOptions<MyCustomCallback>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<MyCustomCallback>>().type.toBeAssignableWith(
       functionProp<MyCustomCallback>().required,
     );
-    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignableWith(
       functionProp().required,
     );
 
-    expect(createVue2Component(functionProp().required)).type.toEqual<
+    expect(createVue2Component(functionProp().required)).type.toBe<
       Vue2ComponentWithProp<Function>
     >();
 
     expect(
       createVue2Component(functionProp<MyCustomCallback>().required),
-    ).type.toEqual<Vue2ComponentWithProp<MyCustomCallback>>();
+    ).type.toBe<Vue2ComponentWithProp<MyCustomCallback>>();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<Function>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<Function>>().type.toBeAssignableWith(
       functionProp().required,
     );
-    expect<Vue2_7.PropOptions<MyCustomCallback>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<MyCustomCallback>>().type.toBeAssignableWith(
       functionProp<MyCustomCallback>().required,
     );
-    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignableWith(
       functionProp().required,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<Function>>().type.toBeAssignable(functionProp().required);
-    expect<Vue3.Prop<MyCustomCallback>>().type.toBeAssignable(
+    expect<Vue3.Prop<Function>>().type.toBeAssignableWith(
+      functionProp().required,
+    );
+    expect<Vue3.Prop<MyCustomCallback>>().type.toBeAssignableWith(
       functionProp<MyCustomCallback>().required,
     );
-    expect<Vue3.Prop<string>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<string>>().type.not.toBeAssignableWith(
       functionProp().required,
     );
   });

--- a/type-tests/prop-types/instanceOf.type.spec.ts
+++ b/type-tests/prop-types/instanceOf.type.spec.ts
@@ -15,32 +15,32 @@ class Account {
 
 describe('instanceOfProp().optional', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<User | undefined>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<User | undefined>>().type.toBeAssignableWith(
       instanceOfProp(User).optional,
     );
-    expect<Vue2_6.PropOptions<Account | undefined>>().type.not.toBeAssignable(
-      instanceOfProp(User).optional,
-    );
+    expect<
+      Vue2_6.PropOptions<Account | undefined>
+    >().type.not.toBeAssignableWith(instanceOfProp(User).optional);
 
-    expect(createVue2Component(instanceOfProp(User).optional)).type.toEqual<
+    expect(createVue2Component(instanceOfProp(User).optional)).type.toBe<
       Vue2ComponentWithProp<User | undefined>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<User | undefined>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<User | undefined>>().type.toBeAssignableWith(
       instanceOfProp(User).optional,
     );
-    expect<Vue2_7.PropOptions<Account>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<Account>>().type.not.toBeAssignableWith(
       instanceOfProp(User).optional,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<User | undefined>>().type.toBeAssignable(
+    expect<Vue3.Prop<User | undefined>>().type.toBeAssignableWith(
       instanceOfProp(User).optional,
     );
-    expect<Vue3.Prop<Account>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<Account>>().type.not.toBeAssignableWith(
       instanceOfProp(User).optional,
     );
   });
@@ -48,32 +48,32 @@ describe('instanceOfProp().optional', () => {
 
 describe('instanceOfProp().nullable', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<User | undefined>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<User | undefined>>().type.toBeAssignableWith(
       instanceOfProp(User).optional,
     );
-    expect<Vue2_6.PropOptions<Account | undefined>>().type.not.toBeAssignable(
-      instanceOfProp(User).optional,
-    );
+    expect<
+      Vue2_6.PropOptions<Account | undefined>
+    >().type.not.toBeAssignableWith(instanceOfProp(User).optional);
 
-    expect(createVue2Component(instanceOfProp(User).optional)).type.toEqual<
+    expect(createVue2Component(instanceOfProp(User).optional)).type.toBe<
       Vue2ComponentWithProp<User | undefined>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<User | undefined>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<User | undefined>>().type.toBeAssignableWith(
       instanceOfProp(User).optional,
     );
-    expect<Vue2_7.PropOptions<Account>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<Account>>().type.not.toBeAssignableWith(
       instanceOfProp(User).optional,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<User | undefined>>().type.toBeAssignable(
+    expect<Vue3.Prop<User | undefined>>().type.toBeAssignableWith(
       instanceOfProp(User).optional,
     );
-    expect<Vue3.Prop<Account>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<Account>>().type.not.toBeAssignableWith(
       instanceOfProp(User).optional,
     );
   });
@@ -81,32 +81,32 @@ describe('instanceOfProp().nullable', () => {
 
 describe('instanceOfProp().withDefault', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<User>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<User>>().type.toBeAssignableWith(
       instanceOfProp(User).withDefault(() => new User()),
     );
-    expect<Vue2_6.PropOptions<Account>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<Account>>().type.not.toBeAssignableWith(
       instanceOfProp(User).withDefault(() => new User()),
     );
 
     expect(
       createVue2Component(instanceOfProp(User).withDefault(() => new User())),
-    ).type.toEqual<Vue2ComponentWithProp<User>>();
+    ).type.toBe<Vue2ComponentWithProp<User>>();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<User>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<User>>().type.toBeAssignableWith(
       instanceOfProp(User).withDefault(() => new User()),
     );
-    expect<Vue2_7.PropOptions<Account>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<Account>>().type.not.toBeAssignableWith(
       instanceOfProp(User).withDefault(() => new User()),
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<User>>().type.toBeAssignable(
+    expect<Vue3.Prop<User>>().type.toBeAssignableWith(
       instanceOfProp(User).withDefault(() => new User()),
     );
-    expect<Vue3.Prop<Account>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<Account>>().type.not.toBeAssignableWith(
       instanceOfProp(User).withDefault(() => new User()),
     );
   });
@@ -114,32 +114,32 @@ describe('instanceOfProp().withDefault', () => {
 
 describe('instanceOfProp().required', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<User>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<User>>().type.toBeAssignableWith(
       instanceOfProp(User).required,
     );
-    expect<Vue2_6.PropOptions<Account>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<Account>>().type.not.toBeAssignableWith(
       instanceOfProp(User).required,
     );
 
-    expect(createVue2Component(instanceOfProp(User).required)).type.toEqual<
+    expect(createVue2Component(instanceOfProp(User).required)).type.toBe<
       Vue2ComponentWithProp<User>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<User>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<User>>().type.toBeAssignableWith(
       instanceOfProp(User).required,
     );
-    expect<Vue2_7.PropOptions<Account>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<Account>>().type.not.toBeAssignableWith(
       instanceOfProp(User).required,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<User>>().type.toBeAssignable(
+    expect<Vue3.Prop<User>>().type.toBeAssignableWith(
       instanceOfProp(User).required,
     );
-    expect<Vue3.Prop<Account>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<Account>>().type.not.toBeAssignableWith(
       instanceOfProp(User).required,
     );
   });

--- a/type-tests/prop-types/integer.type.spec.ts
+++ b/type-tests/prop-types/integer.type.spec.ts
@@ -8,94 +8,98 @@ import type { Vue2ComponentWithProp } from '../utils';
 
 describe('integerProp().optional', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<number | undefined>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<number | undefined>>().type.toBeAssignableWith(
       integerProp().optional,
     );
-    expect<Vue2_6.PropOptions<number>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<number>>().type.not.toBeAssignableWith(
       integerProp().optional,
     );
 
-    expect(createVue2Component(integerProp().optional)).type.toEqual<
+    expect(createVue2Component(integerProp().optional)).type.toBe<
       Vue2ComponentWithProp<number | undefined>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<number | undefined>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<number | undefined>>().type.toBeAssignableWith(
       integerProp().optional,
     );
-    expect<Vue2_7.PropOptions<number>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<number>>().type.not.toBeAssignableWith(
       integerProp().optional,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<number | undefined>>().type.toBeAssignable(
+    expect<Vue3.Prop<number | undefined>>().type.toBeAssignableWith(
       integerProp().optional,
     );
-    expect<Vue3.Prop<number>>().type.not.toBeAssignable(integerProp().optional);
+    expect<Vue3.Prop<number>>().type.not.toBeAssignableWith(
+      integerProp().optional,
+    );
   });
 });
 
 describe('integerProp().nullable', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<number | null>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<number | null>>().type.toBeAssignableWith(
       integerProp().nullable,
     );
-    expect<Vue2_6.PropOptions<number>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<number>>().type.not.toBeAssignableWith(
       integerProp().nullable,
     );
 
-    expect(createVue2Component(integerProp().nullable)).type.toEqual<
+    expect(createVue2Component(integerProp().nullable)).type.toBe<
       Vue2ComponentWithProp<number | null>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<number | null>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<number | null>>().type.toBeAssignableWith(
       integerProp().nullable,
     );
-    expect<Vue2_7.PropOptions<number>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<number>>().type.not.toBeAssignableWith(
       integerProp().nullable,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<number | null>>().type.toBeAssignable(
+    expect<Vue3.Prop<number | null>>().type.toBeAssignableWith(
       integerProp().nullable,
     );
-    expect<Vue3.Prop<number>>().type.not.toBeAssignable(integerProp().nullable);
+    expect<Vue3.Prop<number>>().type.not.toBeAssignableWith(
+      integerProp().nullable,
+    );
   });
 });
 
 describe('integerProp().withDefault', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<number>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<number>>().type.toBeAssignableWith(
       integerProp().withDefault(27),
     );
-    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignableWith(
       integerProp().withDefault(27),
     );
 
-    expect(createVue2Component(integerProp().withDefault(27))).type.toEqual<
+    expect(createVue2Component(integerProp().withDefault(27))).type.toBe<
       Vue2ComponentWithProp<number>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<number>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<number>>().type.toBeAssignableWith(
       integerProp().withDefault(27),
     );
-    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignableWith(
       integerProp().withDefault(27),
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<number>>().type.toBeAssignable(
+    expect<Vue3.Prop<number>>().type.toBeAssignableWith(
       integerProp().withDefault(27),
     );
-    expect<Vue3.Prop<string>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<string>>().type.not.toBeAssignableWith(
       integerProp().withDefault(27),
     );
   });
@@ -103,29 +107,31 @@ describe('integerProp().withDefault', () => {
 
 describe('integerProp().required', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<number>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<number>>().type.toBeAssignableWith(
       integerProp().required,
     );
-    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignableWith(
       integerProp().required,
     );
 
-    expect(createVue2Component(integerProp().required)).type.toEqual<
+    expect(createVue2Component(integerProp().required)).type.toBe<
       Vue2ComponentWithProp<number>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<number>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<number>>().type.toBeAssignableWith(
       integerProp().required,
     );
-    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignableWith(
       integerProp().required,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<number>>().type.toBeAssignable(integerProp().required);
-    expect<Vue3.Prop<string>>().type.not.toBeAssignable(integerProp().required);
+    expect<Vue3.Prop<number>>().type.toBeAssignableWith(integerProp().required);
+    expect<Vue3.Prop<string>>().type.not.toBeAssignableWith(
+      integerProp().required,
+    );
   });
 });

--- a/type-tests/prop-types/number.type.spec.ts
+++ b/type-tests/prop-types/number.type.spec.ts
@@ -10,90 +10,94 @@ type Foo = 1 | 2 | 3;
 
 describe('numberProp().optional', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<number | undefined>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<number | undefined>>().type.toBeAssignableWith(
       numberProp().optional,
     );
-    expect<Vue2_6.PropOptions<number>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<number>>().type.not.toBeAssignableWith(
       numberProp().optional,
     );
 
-    expect(createVue2Component(numberProp().optional)).type.toEqual<
+    expect(createVue2Component(numberProp().optional)).type.toBe<
       Vue2ComponentWithProp<number | undefined>
     >();
 
-    expect(createVue2Component(numberProp<Foo>().optional)).type.toEqual<
+    expect(createVue2Component(numberProp<Foo>().optional)).type.toBe<
       Vue2ComponentWithProp<Foo | undefined>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<number | undefined>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<number | undefined>>().type.toBeAssignableWith(
       numberProp().optional,
     );
-    expect<Vue2_7.PropOptions<Foo | undefined>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<Foo | undefined>>().type.toBeAssignableWith(
       numberProp<Foo>().optional,
     );
-    expect<Vue2_7.PropOptions<number>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<number>>().type.not.toBeAssignableWith(
       numberProp().optional,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<number | undefined>>().type.toBeAssignable(
+    expect<Vue3.Prop<number | undefined>>().type.toBeAssignableWith(
       numberProp().optional,
     );
-    expect<Vue3.Prop<Foo | undefined>>().type.toBeAssignable(
+    expect<Vue3.Prop<Foo | undefined>>().type.toBeAssignableWith(
       numberProp<Foo>().optional,
     );
-    expect<Vue3.Prop<number>>().type.not.toBeAssignable(numberProp().optional);
+    expect<Vue3.Prop<number>>().type.not.toBeAssignableWith(
+      numberProp().optional,
+    );
   });
 });
 
 describe('numberProp().nullable', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<number | null>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<number | null>>().type.toBeAssignableWith(
       numberProp().nullable,
     );
-    expect<Vue2_6.PropOptions<Foo | null>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<Foo | null>>().type.toBeAssignableWith(
       numberProp<Foo>().nullable,
     );
-    expect<Vue2_6.PropOptions<number>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<number>>().type.not.toBeAssignableWith(
       numberProp().nullable,
     );
-    expect<Vue2_6.PropOptions<Foo>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<Foo>>().type.not.toBeAssignableWith(
       numberProp<Foo>().nullable,
     );
 
-    expect(createVue2Component(numberProp().nullable)).type.toEqual<
+    expect(createVue2Component(numberProp().nullable)).type.toBe<
       Vue2ComponentWithProp<number | null>
     >();
 
-    expect(createVue2Component(numberProp<Foo>().nullable)).type.toEqual<
+    expect(createVue2Component(numberProp<Foo>().nullable)).type.toBe<
       Vue2ComponentWithProp<Foo | null>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<number | null>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<number | null>>().type.toBeAssignableWith(
       numberProp().nullable,
     );
-    expect<Vue2_7.PropOptions<Foo | null>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<Foo | null>>().type.toBeAssignableWith(
       numberProp<Foo>().nullable,
     );
-    expect<Vue2_7.PropOptions<number>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<number>>().type.not.toBeAssignableWith(
       numberProp().nullable,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<number | null>>().type.toBeAssignable(
+    expect<Vue3.Prop<number | null>>().type.toBeAssignableWith(
       numberProp().nullable,
     );
-    expect<Vue3.Prop<Foo | null>>().type.toBeAssignable(
+    expect<Vue3.Prop<Foo | null>>().type.toBeAssignableWith(
       numberProp<Foo>().nullable,
     );
-    expect<Vue3.Prop<number>>().type.not.toBeAssignable(numberProp().nullable);
-    expect<Vue3.Prop<Foo>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<number>>().type.not.toBeAssignableWith(
+      numberProp().nullable,
+    );
+    expect<Vue3.Prop<Foo>>().type.not.toBeAssignableWith(
       numberProp<Foo>().nullable,
     );
   });
@@ -101,51 +105,51 @@ describe('numberProp().nullable', () => {
 
 describe('numberProp().withDefault', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<number>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<number>>().type.toBeAssignableWith(
       numberProp().withDefault(27),
     );
-    expect<Vue2_6.PropOptions<Foo>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<Foo>>().type.toBeAssignableWith(
       numberProp<Foo>().withDefault(1),
     );
-    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignableWith(
       numberProp().withDefault(27),
     );
 
-    expect(createVue2Component(numberProp().withDefault(27))).type.toEqual<
+    expect(createVue2Component(numberProp().withDefault(27))).type.toBe<
       Vue2ComponentWithProp<number>
     >();
 
-    expect(createVue2Component(numberProp<Foo>().withDefault(1))).type.toEqual<
+    expect(createVue2Component(numberProp<Foo>().withDefault(1))).type.toBe<
       Vue2ComponentWithProp<Foo>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<number>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<number>>().type.toBeAssignableWith(
       numberProp().withDefault(27),
     );
-    expect<Vue2_7.PropOptions<Foo>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<Foo>>().type.toBeAssignableWith(
       numberProp<Foo>().withDefault(1),
     );
-    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignableWith(
       numberProp().withDefault(27),
     );
-    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignableWith(
       numberProp<Foo>().withDefault(1),
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<number>>().type.toBeAssignable(
+    expect<Vue3.Prop<number>>().type.toBeAssignableWith(
       numberProp().withDefault(27),
     );
-    expect<Vue3.Prop<Foo>>().type.toBeAssignable(
+    expect<Vue3.Prop<Foo>>().type.toBeAssignableWith(
       numberProp<Foo>().withDefault(1),
     );
-    expect<Vue3.Prop<string>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<string>>().type.not.toBeAssignableWith(
       numberProp().withDefault(27),
     );
-    expect<Vue3.Prop<string>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<string>>().type.not.toBeAssignableWith(
       numberProp<Foo>().withDefault(1),
     );
   });
@@ -153,48 +157,52 @@ describe('numberProp().withDefault', () => {
 
 describe('numberProp().required', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<number>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<number>>().type.toBeAssignableWith(
       numberProp().required,
     );
-    expect<Vue2_6.PropOptions<Foo>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<Foo>>().type.toBeAssignableWith(
       numberProp<Foo>().required,
     );
-    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignableWith(
       numberProp().required,
     );
-    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignableWith(
       numberProp<Foo>().required,
     );
 
-    expect(createVue2Component(numberProp().required)).type.toEqual<
+    expect(createVue2Component(numberProp().required)).type.toBe<
       Vue2ComponentWithProp<number>
     >();
 
-    expect(createVue2Component(numberProp<Foo>().required)).type.toEqual<
+    expect(createVue2Component(numberProp<Foo>().required)).type.toBe<
       Vue2ComponentWithProp<Foo>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<number>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<number>>().type.toBeAssignableWith(
       numberProp().required,
     );
-    expect<Vue2_7.PropOptions<Foo>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<Foo>>().type.toBeAssignableWith(
       numberProp<Foo>().required,
     );
-    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignableWith(
       numberProp().required,
     );
-    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignableWith(
       numberProp<Foo>().required,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<number>>().type.toBeAssignable(numberProp().required);
-    expect<Vue3.Prop<Foo>>().type.toBeAssignable(numberProp<Foo>().required);
-    expect<Vue3.Prop<string>>().type.not.toBeAssignable(numberProp().required);
-    expect<Vue3.Prop<string>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<number>>().type.toBeAssignableWith(numberProp().required);
+    expect<Vue3.Prop<Foo>>().type.toBeAssignableWith(
+      numberProp<Foo>().required,
+    );
+    expect<Vue3.Prop<string>>().type.not.toBeAssignableWith(
+      numberProp().required,
+    );
+    expect<Vue3.Prop<string>>().type.not.toBeAssignableWith(
       numberProp<Foo>().required,
     );
   });

--- a/type-tests/prop-types/object.type.spec.ts
+++ b/type-tests/prop-types/object.type.spec.ts
@@ -12,45 +12,45 @@ interface User {
 
 describe('objectProp().optional', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<object | undefined>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<object | undefined>>().type.toBeAssignableWith(
       objectProp().optional,
     );
-    expect<Vue2_6.PropOptions<User | undefined>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<User | undefined>>().type.toBeAssignableWith(
       objectProp<User>().optional,
     );
-    expect<Vue2_6.PropOptions<User>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<User>>().type.not.toBeAssignableWith(
       objectProp<User>().optional,
     );
 
-    expect(createVue2Component(objectProp().optional)).type.toEqual<
+    expect(createVue2Component(objectProp().optional)).type.toBe<
       Vue2ComponentWithProp<object | undefined>
     >();
 
-    expect(createVue2Component(objectProp<User>().optional)).type.toEqual<
+    expect(createVue2Component(objectProp<User>().optional)).type.toBe<
       Vue2ComponentWithProp<User | undefined>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<object | undefined>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<object | undefined>>().type.toBeAssignableWith(
       objectProp().optional,
     );
-    expect<Vue2_7.PropOptions<User | undefined>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<User | undefined>>().type.toBeAssignableWith(
       objectProp<User>().optional,
     );
-    expect<Vue2_7.PropOptions<User>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<User>>().type.not.toBeAssignableWith(
       objectProp<User>().optional,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<object | undefined>>().type.toBeAssignable(
+    expect<Vue3.Prop<object | undefined>>().type.toBeAssignableWith(
       objectProp().optional,
     );
-    expect<Vue3.Prop<User | undefined>>().type.toBeAssignable(
+    expect<Vue3.Prop<User | undefined>>().type.toBeAssignableWith(
       objectProp<User>().optional,
     );
-    expect<Vue3.Prop<User>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<User>>().type.not.toBeAssignableWith(
       objectProp<User>().optional,
     );
   });
@@ -58,45 +58,45 @@ describe('objectProp().optional', () => {
 
 describe('objectProp().nullable', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<object | null>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<object | null>>().type.toBeAssignableWith(
       objectProp().nullable,
     );
-    expect<Vue2_6.PropOptions<User | null>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<User | null>>().type.toBeAssignableWith(
       objectProp<User>().nullable,
     );
-    expect<Vue2_6.PropOptions<User>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<User>>().type.not.toBeAssignableWith(
       objectProp<User>().nullable,
     );
 
-    expect(createVue2Component(objectProp().nullable)).type.toEqual<
+    expect(createVue2Component(objectProp().nullable)).type.toBe<
       Vue2ComponentWithProp<object | null>
     >();
 
-    expect(createVue2Component(objectProp<User>().nullable)).type.toEqual<
+    expect(createVue2Component(objectProp<User>().nullable)).type.toBe<
       Vue2ComponentWithProp<User | null>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<object | null>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<object | null>>().type.toBeAssignableWith(
       objectProp().nullable,
     );
-    expect<Vue2_7.PropOptions<User | null>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<User | null>>().type.toBeAssignableWith(
       objectProp<User>().nullable,
     );
-    expect<Vue2_7.PropOptions<User>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<User>>().type.not.toBeAssignableWith(
       objectProp<User>().nullable,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<object | null>>().type.toBeAssignable(
+    expect<Vue3.Prop<object | null>>().type.toBeAssignableWith(
       objectProp().nullable,
     );
-    expect<Vue3.Prop<User | null>>().type.toBeAssignable(
+    expect<Vue3.Prop<User | null>>().type.toBeAssignableWith(
       objectProp<User>().nullable,
     );
-    expect<Vue3.Prop<User>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<User>>().type.not.toBeAssignableWith(
       objectProp<User>().nullable,
     );
   });
@@ -106,23 +106,23 @@ const userGenerator = () => ({ name: 'bar' });
 
 describe('objectProp().withDefault', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<User>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<User>>().type.toBeAssignableWith(
       objectProp<User>().withDefault(userGenerator),
     );
 
     expect(
       createVue2Component(objectProp<User>().withDefault(userGenerator)),
-    ).type.toEqual<Vue2ComponentWithProp<User>>();
+    ).type.toBe<Vue2ComponentWithProp<User>>();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<User>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<User>>().type.toBeAssignableWith(
       objectProp<User>().withDefault(userGenerator),
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<User>>().type.toBeAssignable(
+    expect<Vue3.Prop<User>>().type.toBeAssignableWith(
       objectProp<User>().withDefault(userGenerator),
     );
   });
@@ -130,33 +130,35 @@ describe('objectProp().withDefault', () => {
 
 describe('objectProp().required', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<object>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<object>>().type.toBeAssignableWith(
       objectProp().required,
     );
-    expect<Vue2_6.PropOptions<User>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<User>>().type.toBeAssignableWith(
       objectProp<User>().required,
     );
 
-    expect(createVue2Component(objectProp().required)).type.toEqual<
+    expect(createVue2Component(objectProp().required)).type.toBe<
       Vue2ComponentWithProp<object>
     >();
 
-    expect(createVue2Component(objectProp<User>().required)).type.toEqual<
+    expect(createVue2Component(objectProp<User>().required)).type.toBe<
       Vue2ComponentWithProp<User>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<object>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<object>>().type.toBeAssignableWith(
       objectProp().required,
     );
-    expect<Vue2_7.PropOptions<User>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<User>>().type.toBeAssignableWith(
       objectProp<User>().required,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<object>>().type.toBeAssignable(objectProp().required);
-    expect<Vue3.Prop<User>>().type.toBeAssignable(objectProp<User>().required);
+    expect<Vue3.Prop<object>>().type.toBeAssignableWith(objectProp().required);
+    expect<Vue3.Prop<User>>().type.toBeAssignableWith(
+      objectProp<User>().required,
+    );
   });
 });

--- a/type-tests/prop-types/oneOf.type.spec.ts
+++ b/type-tests/prop-types/oneOf.type.spec.ts
@@ -11,32 +11,32 @@ type Options = 'a' | 'b' | 'c';
 
 describe('oneOfProp().optional', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<string | undefined>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<string | undefined>>().type.toBeAssignableWith(
       oneOfProp(['a', 'b', 'c']).optional,
     );
-    expect<Vue2_6.PropOptions<Options | undefined>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<Options | undefined>>().type.toBeAssignableWith(
       oneOfProp(options).optional,
     );
 
-    expect(createVue2Component(oneOfProp(options).optional)).type.toEqual<
+    expect(createVue2Component(oneOfProp(options).optional)).type.toBe<
       Vue2ComponentWithProp<Options | undefined>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<string | undefined>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<string | undefined>>().type.toBeAssignableWith(
       oneOfProp(['a', 'b', 'c']).optional,
     );
-    expect<Vue2_7.PropOptions<Options | undefined>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<Options | undefined>>().type.toBeAssignableWith(
       oneOfProp(options).optional,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<string | undefined>>().type.toBeAssignable(
+    expect<Vue3.Prop<string | undefined>>().type.toBeAssignableWith(
       oneOfProp(['a', 'b', 'c']).optional,
     );
-    expect<Vue3.Prop<Options | undefined>>().type.toBeAssignable(
+    expect<Vue3.Prop<Options | undefined>>().type.toBeAssignableWith(
       oneOfProp(options).optional,
     );
   });
@@ -44,32 +44,32 @@ describe('oneOfProp().optional', () => {
 
 describe('oneOfProp().nullable', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<string | null>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<string | null>>().type.toBeAssignableWith(
       oneOfProp(['a', 'b', 'c']).nullable,
     );
-    expect<Vue2_6.PropOptions<Options | null>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<Options | null>>().type.toBeAssignableWith(
       oneOfProp(options).nullable,
     );
 
-    expect(createVue2Component(oneOfProp(options).nullable)).type.toEqual<
+    expect(createVue2Component(oneOfProp(options).nullable)).type.toBe<
       Vue2ComponentWithProp<Options | null>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<string | null>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<string | null>>().type.toBeAssignableWith(
       oneOfProp(['a', 'b', 'c']).nullable,
     );
-    expect<Vue2_7.PropOptions<Options | null>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<Options | null>>().type.toBeAssignableWith(
       oneOfProp(options).nullable,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<string | null>>().type.toBeAssignable(
+    expect<Vue3.Prop<string | null>>().type.toBeAssignableWith(
       oneOfProp(['a', 'b', 'c']).nullable,
     );
-    expect<Vue3.Prop<Options | null>>().type.toBeAssignable(
+    expect<Vue3.Prop<Options | null>>().type.toBeAssignableWith(
       oneOfProp(options).nullable,
     );
   });
@@ -77,23 +77,23 @@ describe('oneOfProp().nullable', () => {
 
 describe('oneOfProp().withDefault', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<Options>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<Options>>().type.toBeAssignableWith(
       oneOfProp(options).withDefault('a'),
     );
 
-    expect(
-      createVue2Component(oneOfProp(options).withDefault('a')),
-    ).type.toEqual<Vue2ComponentWithProp<Options>>();
+    expect(createVue2Component(oneOfProp(options).withDefault('a'))).type.toBe<
+      Vue2ComponentWithProp<Options>
+    >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<Options>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<Options>>().type.toBeAssignableWith(
       oneOfProp(options).withDefault('a'),
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<Options>>().type.toBeAssignable(
+    expect<Vue3.Prop<Options>>().type.toBeAssignableWith(
       oneOfProp(options).withDefault('a'),
     );
   });
@@ -101,23 +101,23 @@ describe('oneOfProp().withDefault', () => {
 
 describe('oneOfProp().required', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<Options>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<Options>>().type.toBeAssignableWith(
       oneOfProp(options).required,
     );
 
-    expect(createVue2Component(oneOfProp(options).required)).type.toEqual<
+    expect(createVue2Component(oneOfProp(options).required)).type.toBe<
       Vue2ComponentWithProp<Options>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<Options>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<Options>>().type.toBeAssignableWith(
       oneOfProp(options).required,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<Options>>().type.toBeAssignable(
+    expect<Vue3.Prop<Options>>().type.toBeAssignableWith(
       oneOfProp(options).required,
     );
   });

--- a/type-tests/prop-types/oneOfObjectKeys.type.spec.ts
+++ b/type-tests/prop-types/oneOfObjectKeys.type.spec.ts
@@ -11,23 +11,23 @@ type Options = 'a' | 'b' | 'c';
 
 describe('oneOfObjectKeysProp().optional', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<Options | undefined>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<Options | undefined>>().type.toBeAssignableWith(
       oneOfObjectKeysProp(options).optional,
     );
 
     expect(
       createVue2Component(oneOfObjectKeysProp(options).optional),
-    ).type.toEqual<Vue2ComponentWithProp<Options | undefined>>();
+    ).type.toBe<Vue2ComponentWithProp<Options | undefined>>();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<Options | undefined>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<Options | undefined>>().type.toBeAssignableWith(
       oneOfObjectKeysProp(options).optional,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<Options | undefined>>().type.toBeAssignable(
+    expect<Vue3.Prop<Options | undefined>>().type.toBeAssignableWith(
       oneOfObjectKeysProp(options).optional,
     );
   });
@@ -35,23 +35,23 @@ describe('oneOfObjectKeysProp().optional', () => {
 
 describe('oneOfObjectKeysProp().nullable', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<Options | null>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<Options | null>>().type.toBeAssignableWith(
       oneOfObjectKeysProp(options).nullable,
     );
 
     expect(
       createVue2Component(oneOfObjectKeysProp(options).nullable),
-    ).type.toEqual<Vue2ComponentWithProp<Options | null>>();
+    ).type.toBe<Vue2ComponentWithProp<Options | null>>();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<Options | null>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<Options | null>>().type.toBeAssignableWith(
       oneOfObjectKeysProp(options).nullable,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<Options | null>>().type.toBeAssignable(
+    expect<Vue3.Prop<Options | null>>().type.toBeAssignableWith(
       oneOfObjectKeysProp(options).nullable,
     );
   });
@@ -59,23 +59,23 @@ describe('oneOfObjectKeysProp().nullable', () => {
 
 describe('oneOfObjectKeysProp().withDefault', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<Options>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<Options>>().type.toBeAssignableWith(
       oneOfObjectKeysProp(options).withDefault('a'),
     );
 
     expect(
       createVue2Component(oneOfObjectKeysProp(options).withDefault('a')),
-    ).type.toEqual<Vue2ComponentWithProp<Options>>();
+    ).type.toBe<Vue2ComponentWithProp<Options>>();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<Options>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<Options>>().type.toBeAssignableWith(
       oneOfObjectKeysProp(options).withDefault('a'),
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<Options>>().type.toBeAssignable(
+    expect<Vue3.Prop<Options>>().type.toBeAssignableWith(
       oneOfObjectKeysProp(options).withDefault('a'),
     );
   });
@@ -83,23 +83,23 @@ describe('oneOfObjectKeysProp().withDefault', () => {
 
 describe('oneOfObjectKeysProp().required', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<Options>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<Options>>().type.toBeAssignableWith(
       oneOfObjectKeysProp(options).required,
     );
 
     expect(
       createVue2Component(oneOfObjectKeysProp(options).required),
-    ).type.toEqual<Vue2ComponentWithProp<Options>>();
+    ).type.toBe<Vue2ComponentWithProp<Options>>();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<Options>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<Options>>().type.toBeAssignableWith(
       oneOfObjectKeysProp(options).required,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<Options>>().type.toBeAssignable(
+    expect<Vue3.Prop<Options>>().type.toBeAssignableWith(
       oneOfObjectKeysProp(options).required,
     );
   });

--- a/type-tests/prop-types/oneOfTypes.type.spec.ts
+++ b/type-tests/prop-types/oneOfTypes.type.spec.ts
@@ -11,23 +11,23 @@ type Options = number | string;
 
 describe('oneOfTypesProp().optional', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<Options | undefined>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<Options | undefined>>().type.toBeAssignableWith(
       oneOfTypesProp<Options>(options).optional,
     );
 
     expect(
       createVue2Component(oneOfTypesProp<Options>(options).optional),
-    ).type.toEqual<Vue2ComponentWithProp<Options | undefined>>();
+    ).type.toBe<Vue2ComponentWithProp<Options | undefined>>();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<Options | undefined>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<Options | undefined>>().type.toBeAssignableWith(
       oneOfTypesProp<Options>(options).optional,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<Options | undefined>>().type.toBeAssignable(
+    expect<Vue3.Prop<Options | undefined>>().type.toBeAssignableWith(
       oneOfTypesProp<Options>(options).optional,
     );
   });
@@ -35,23 +35,23 @@ describe('oneOfTypesProp().optional', () => {
 
 describe('oneOfTypesProp().nullable', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<Options | null>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<Options | null>>().type.toBeAssignableWith(
       oneOfTypesProp<Options>(options).nullable,
     );
 
     expect(
       createVue2Component(oneOfTypesProp<Options>(options).nullable),
-    ).type.toEqual<Vue2ComponentWithProp<Options | null>>();
+    ).type.toBe<Vue2ComponentWithProp<Options | null>>();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<Options | null>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<Options | null>>().type.toBeAssignableWith(
       oneOfTypesProp<Options>(options).nullable,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<Options | null>>().type.toBeAssignable(
+    expect<Vue3.Prop<Options | null>>().type.toBeAssignableWith(
       oneOfTypesProp<Options>(options).nullable,
     );
   });
@@ -59,23 +59,23 @@ describe('oneOfTypesProp().nullable', () => {
 
 describe('oneOfTypesProp().withDefault', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<Options>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<Options>>().type.toBeAssignableWith(
       oneOfTypesProp<Options>(options).withDefault('a'),
     );
 
     expect(
       createVue2Component(oneOfTypesProp<Options>(options).withDefault('a')),
-    ).type.toEqual<Vue2ComponentWithProp<Options>>();
+    ).type.toBe<Vue2ComponentWithProp<Options>>();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<Options>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<Options>>().type.toBeAssignableWith(
       oneOfTypesProp<Options>(options).withDefault('a'),
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<Options>>().type.toBeAssignable(
+    expect<Vue3.Prop<Options>>().type.toBeAssignableWith(
       oneOfTypesProp<Options>(options).withDefault('a'),
     );
   });
@@ -83,23 +83,23 @@ describe('oneOfTypesProp().withDefault', () => {
 
 describe('oneOfTypesProp().required', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<Options>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<Options>>().type.toBeAssignableWith(
       oneOfTypesProp<Options>(options).required,
     );
 
     expect(
       createVue2Component(oneOfTypesProp<Options>(options).required),
-    ).type.toEqual<Vue2ComponentWithProp<Options>>();
+    ).type.toBe<Vue2ComponentWithProp<Options>>();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<Options>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<Options>>().type.toBeAssignableWith(
       oneOfTypesProp<Options>(options).required,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<Options>>().type.toBeAssignable(
+    expect<Vue3.Prop<Options>>().type.toBeAssignableWith(
       oneOfTypesProp<Options>(options).required,
     );
   });

--- a/type-tests/prop-types/string.type.spec.ts
+++ b/type-tests/prop-types/string.type.spec.ts
@@ -10,52 +10,54 @@ type Foo = 'a' | 'b' | 'c';
 
 describe('stringProp().optional', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<string | undefined>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<string | undefined>>().type.toBeAssignableWith(
       stringProp().optional,
     );
-    expect<Vue2_6.PropOptions<Foo | undefined>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<Foo | undefined>>().type.toBeAssignableWith(
       stringProp<Foo>().optional,
     );
-    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignableWith(
       stringProp().optional,
     );
-    expect<Vue2_6.PropOptions<Foo>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<Foo>>().type.not.toBeAssignableWith(
       stringProp<Foo>().optional,
     );
 
-    expect(createVue2Component(stringProp().optional)).type.toEqual<
+    expect(createVue2Component(stringProp().optional)).type.toBe<
       Vue2ComponentWithProp<string | undefined>
     >();
 
-    expect(createVue2Component(stringProp<Foo>().optional)).type.toEqual<
+    expect(createVue2Component(stringProp<Foo>().optional)).type.toBe<
       Vue2ComponentWithProp<Foo | undefined>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<string | undefined>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<string | undefined>>().type.toBeAssignableWith(
       stringProp().optional,
     );
-    expect<Vue2_7.PropOptions<Foo | undefined>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<Foo | undefined>>().type.toBeAssignableWith(
       stringProp<Foo>().optional,
     );
-    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignableWith(
       stringProp().optional,
     );
-    expect<Vue2_7.PropOptions<Foo>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<Foo>>().type.not.toBeAssignableWith(
       stringProp<Foo>().optional,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<string | undefined>>().type.toBeAssignable(
+    expect<Vue3.Prop<string | undefined>>().type.toBeAssignableWith(
       stringProp().optional,
     );
-    expect<Vue3.Prop<Foo | undefined>>().type.toBeAssignable(
+    expect<Vue3.Prop<Foo | undefined>>().type.toBeAssignableWith(
       stringProp<Foo>().optional,
     );
-    expect<Vue3.Prop<string>>().type.not.toBeAssignable(stringProp().optional);
-    expect<Vue3.Prop<Foo>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<string>>().type.not.toBeAssignableWith(
+      stringProp().optional,
+    );
+    expect<Vue3.Prop<Foo>>().type.not.toBeAssignableWith(
       stringProp<Foo>().optional,
     );
   });
@@ -63,52 +65,54 @@ describe('stringProp().optional', () => {
 
 describe('stringProp().nullable', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<string | null>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<string | null>>().type.toBeAssignableWith(
       stringProp().nullable,
     );
-    expect<Vue2_6.PropOptions<Foo | null>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<Foo | null>>().type.toBeAssignableWith(
       stringProp<Foo>().nullable,
     );
-    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignableWith(
       stringProp().nullable,
     );
-    expect<Vue2_6.PropOptions<Foo>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<Foo>>().type.not.toBeAssignableWith(
       stringProp<Foo>().nullable,
     );
 
-    expect(createVue2Component(stringProp().nullable)).type.toEqual<
+    expect(createVue2Component(stringProp().nullable)).type.toBe<
       Vue2ComponentWithProp<string | null>
     >();
 
-    expect(createVue2Component(stringProp<Foo>().nullable)).type.toEqual<
+    expect(createVue2Component(stringProp<Foo>().nullable)).type.toBe<
       Vue2ComponentWithProp<Foo | null>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<string | null>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<string | null>>().type.toBeAssignableWith(
       stringProp().nullable,
     );
-    expect<Vue2_7.PropOptions<Foo | null>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<Foo | null>>().type.toBeAssignableWith(
       stringProp<Foo>().nullable,
     );
-    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignableWith(
       stringProp().nullable,
     );
-    expect<Vue2_7.PropOptions<Foo>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<Foo>>().type.not.toBeAssignableWith(
       stringProp<Foo>().nullable,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<string | null>>().type.toBeAssignable(
+    expect<Vue3.Prop<string | null>>().type.toBeAssignableWith(
       stringProp().nullable,
     );
-    expect<Vue3.Prop<Foo | null>>().type.toBeAssignable(
+    expect<Vue3.Prop<Foo | null>>().type.toBeAssignableWith(
       stringProp<Foo>().nullable,
     );
-    expect<Vue3.Prop<string>>().type.not.toBeAssignable(stringProp().nullable);
-    expect<Vue3.Prop<Foo>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<string>>().type.not.toBeAssignableWith(
+      stringProp().nullable,
+    );
+    expect<Vue3.Prop<Foo>>().type.not.toBeAssignableWith(
       stringProp<Foo>().nullable,
     );
   });
@@ -116,54 +120,54 @@ describe('stringProp().nullable', () => {
 
 describe('stringProp().withDefault', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<string>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<string>>().type.toBeAssignableWith(
       stringProp().withDefault('foo'),
     );
-    expect<Vue2_6.PropOptions<Foo>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<Foo>>().type.toBeAssignableWith(
       stringProp<Foo>().withDefault('a'),
     );
-    expect<Vue2_6.PropOptions<number>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<number>>().type.not.toBeAssignableWith(
       stringProp().withDefault('foo'),
     );
-    expect<Vue2_6.PropOptions<number>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<number>>().type.not.toBeAssignableWith(
       stringProp<Foo>().withDefault('a'),
     );
 
-    expect(createVue2Component(stringProp().withDefault('foo'))).type.toEqual<
+    expect(createVue2Component(stringProp().withDefault('foo'))).type.toBe<
       Vue2ComponentWithProp<string>
     >();
 
-    expect(
-      createVue2Component(stringProp<Foo>().withDefault('a')),
-    ).type.toEqual<Vue2ComponentWithProp<Foo>>();
+    expect(createVue2Component(stringProp<Foo>().withDefault('a'))).type.toBe<
+      Vue2ComponentWithProp<Foo>
+    >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<string>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<string>>().type.toBeAssignableWith(
       stringProp().withDefault('foo'),
     );
-    expect<Vue2_7.PropOptions<Foo>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<Foo>>().type.toBeAssignableWith(
       stringProp<Foo>().withDefault('a'),
     );
-    expect<Vue2_7.PropOptions<number>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<number>>().type.not.toBeAssignableWith(
       stringProp().withDefault('foo'),
     );
-    expect<Vue2_7.PropOptions<number>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<number>>().type.not.toBeAssignableWith(
       stringProp<Foo>().withDefault('a'),
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<string>>().type.toBeAssignable(
+    expect<Vue3.Prop<string>>().type.toBeAssignableWith(
       stringProp().withDefault('foo'),
     );
-    expect<Vue3.Prop<Foo>>().type.toBeAssignable(
+    expect<Vue3.Prop<Foo>>().type.toBeAssignableWith(
       stringProp<Foo>().withDefault('a'),
     );
-    expect<Vue3.Prop<number>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<number>>().type.not.toBeAssignableWith(
       stringProp().withDefault('foo'),
     );
-    expect<Vue3.Prop<number>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<number>>().type.not.toBeAssignableWith(
       stringProp<Foo>().withDefault('a'),
     );
   });
@@ -171,48 +175,52 @@ describe('stringProp().withDefault', () => {
 
 describe('stringProp().required', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<string>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<string>>().type.toBeAssignableWith(
       stringProp().required,
     );
-    expect<Vue2_6.PropOptions<Foo>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<Foo>>().type.toBeAssignableWith(
       stringProp<Foo>().required,
     );
-    expect<Vue2_6.PropOptions<number>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<number>>().type.not.toBeAssignableWith(
       stringProp().required,
     );
-    expect<Vue2_6.PropOptions<number>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<number>>().type.not.toBeAssignableWith(
       stringProp<Foo>().required,
     );
 
-    expect(createVue2Component(stringProp().required)).type.toEqual<
+    expect(createVue2Component(stringProp().required)).type.toBe<
       Vue2ComponentWithProp<string>
     >();
 
-    expect(createVue2Component(stringProp<Foo>().required)).type.toEqual<
+    expect(createVue2Component(stringProp<Foo>().required)).type.toBe<
       Vue2ComponentWithProp<Foo>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<string>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<string>>().type.toBeAssignableWith(
       stringProp().required,
     );
-    expect<Vue2_7.PropOptions<Foo>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<Foo>>().type.toBeAssignableWith(
       stringProp<Foo>().required,
     );
-    expect<Vue2_7.PropOptions<number>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<number>>().type.not.toBeAssignableWith(
       stringProp().required,
     );
-    expect<Vue2_7.PropOptions<number>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<number>>().type.not.toBeAssignableWith(
       stringProp<Foo>().required,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<string>>().type.toBeAssignable(stringProp().required);
-    expect<Vue3.Prop<Foo>>().type.toBeAssignable(stringProp<Foo>().required);
-    expect<Vue3.Prop<number>>().type.not.toBeAssignable(stringProp().required);
-    expect<Vue3.Prop<number>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<string>>().type.toBeAssignableWith(stringProp().required);
+    expect<Vue3.Prop<Foo>>().type.toBeAssignableWith(
+      stringProp<Foo>().required,
+    );
+    expect<Vue3.Prop<number>>().type.not.toBeAssignableWith(
+      stringProp().required,
+    );
+    expect<Vue3.Prop<number>>().type.not.toBeAssignableWith(
       stringProp<Foo>().required,
     );
   });

--- a/type-tests/prop-types/symbol.type.spec.ts
+++ b/type-tests/prop-types/symbol.type.spec.ts
@@ -8,94 +8,98 @@ import type { Vue2ComponentWithProp } from '../utils';
 
 describe('symbolProp().optional', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<symbol | undefined>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<symbol | undefined>>().type.toBeAssignableWith(
       symbolProp().optional,
     );
-    expect<Vue2_6.PropOptions<symbol>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<symbol>>().type.not.toBeAssignableWith(
       symbolProp().optional,
     );
 
-    expect(createVue2Component(symbolProp().optional)).type.toEqual<
+    expect(createVue2Component(symbolProp().optional)).type.toBe<
       Vue2ComponentWithProp<symbol | undefined>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<symbol | undefined>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<symbol | undefined>>().type.toBeAssignableWith(
       symbolProp().optional,
     );
-    expect<Vue2_7.PropOptions<symbol>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<symbol>>().type.not.toBeAssignableWith(
       symbolProp().optional,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<symbol | undefined>>().type.toBeAssignable(
+    expect<Vue3.Prop<symbol | undefined>>().type.toBeAssignableWith(
       symbolProp().optional,
     );
-    expect<Vue3.Prop<symbol>>().type.not.toBeAssignable(symbolProp().optional);
+    expect<Vue3.Prop<symbol>>().type.not.toBeAssignableWith(
+      symbolProp().optional,
+    );
   });
 });
 
 describe('symbolProp().nullable', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<symbol | null>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<symbol | null>>().type.toBeAssignableWith(
       symbolProp().nullable,
     );
-    expect<Vue2_6.PropOptions<symbol>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<symbol>>().type.not.toBeAssignableWith(
       symbolProp().nullable,
     );
 
-    expect(createVue2Component(symbolProp().nullable)).type.toEqual<
+    expect(createVue2Component(symbolProp().nullable)).type.toBe<
       Vue2ComponentWithProp<symbol | null>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<symbol | null>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<symbol | null>>().type.toBeAssignableWith(
       symbolProp().nullable,
     );
-    expect<Vue2_7.PropOptions<symbol>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<symbol>>().type.not.toBeAssignableWith(
       symbolProp().nullable,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<symbol | null>>().type.toBeAssignable(
+    expect<Vue3.Prop<symbol | null>>().type.toBeAssignableWith(
       symbolProp().nullable,
     );
-    expect<Vue3.Prop<symbol>>().type.not.toBeAssignable(symbolProp().nullable);
+    expect<Vue3.Prop<symbol>>().type.not.toBeAssignableWith(
+      symbolProp().nullable,
+    );
   });
 });
 
 describe('symbolProp().withDefault', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<symbol>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<symbol>>().type.toBeAssignableWith(
       symbolProp().withDefault(Symbol.for('foo')),
     );
-    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignableWith(
       symbolProp().withDefault(Symbol.for('foo')),
     );
 
     expect(
       createVue2Component(symbolProp().withDefault(Symbol.for('foo'))),
-    ).type.toEqual<Vue2ComponentWithProp<symbol>>();
+    ).type.toBe<Vue2ComponentWithProp<symbol>>();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<symbol>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<symbol>>().type.toBeAssignableWith(
       symbolProp().withDefault(Symbol.for('foo')),
     );
-    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignableWith(
       symbolProp().withDefault(Symbol.for('foo')),
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<symbol>>().type.toBeAssignable(
+    expect<Vue3.Prop<symbol>>().type.toBeAssignableWith(
       symbolProp().withDefault(Symbol.for('foo')),
     );
-    expect<Vue3.Prop<string>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<string>>().type.not.toBeAssignableWith(
       symbolProp().withDefault(Symbol.for('foo')),
     );
   });
@@ -103,29 +107,31 @@ describe('symbolProp().withDefault', () => {
 
 describe('symbolProp().required', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<symbol>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<symbol>>().type.toBeAssignableWith(
       symbolProp().required,
     );
-    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignableWith(
       symbolProp().required,
     );
 
-    expect(createVue2Component(symbolProp().required)).type.toEqual<
+    expect(createVue2Component(symbolProp().required)).type.toBe<
       Vue2ComponentWithProp<symbol>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<symbol>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<symbol>>().type.toBeAssignableWith(
       symbolProp().required,
     );
-    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignableWith(
       symbolProp().required,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<symbol>>().type.toBeAssignable(symbolProp().required);
-    expect<Vue3.Prop<string>>().type.not.toBeAssignable(symbolProp().required);
+    expect<Vue3.Prop<symbol>>().type.toBeAssignableWith(symbolProp().required);
+    expect<Vue3.Prop<string>>().type.not.toBeAssignableWith(
+      symbolProp().required,
+    );
   });
 });

--- a/type-tests/prop-types/vueComponent.type.spec.ts
+++ b/type-tests/prop-types/vueComponent.type.spec.ts
@@ -9,32 +9,32 @@ import type { Vue2ComponentWithProp } from '../utils';
 
 describe('vueComponentProp().optional', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<VueComponent | undefined>>().type.toBeAssignable(
-      vueComponentProp().optional,
-    );
-    expect<Vue2_6.PropOptions<VueComponent>>().type.not.toBeAssignable(
+    expect<
+      Vue2_6.PropOptions<VueComponent | undefined>
+    >().type.toBeAssignableWith(vueComponentProp().optional);
+    expect<Vue2_6.PropOptions<VueComponent>>().type.not.toBeAssignableWith(
       vueComponentProp().optional,
     );
 
-    expect(createVue2Component(vueComponentProp().optional)).type.toEqual<
+    expect(createVue2Component(vueComponentProp().optional)).type.toBe<
       Vue2ComponentWithProp<VueComponent | undefined>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<VueComponent | undefined>>().type.toBeAssignable(
-      vueComponentProp().optional,
-    );
-    expect<Vue2_7.PropOptions<VueComponent>>().type.not.toBeAssignable(
+    expect<
+      Vue2_7.PropOptions<VueComponent | undefined>
+    >().type.toBeAssignableWith(vueComponentProp().optional);
+    expect<Vue2_7.PropOptions<VueComponent>>().type.not.toBeAssignableWith(
       vueComponentProp().optional,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<VueComponent | undefined>>().type.toBeAssignable(
+    expect<Vue3.Prop<VueComponent | undefined>>().type.toBeAssignableWith(
       vueComponentProp().optional,
     );
-    expect<Vue3.Prop<VueComponent>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<VueComponent>>().type.not.toBeAssignableWith(
       vueComponentProp().optional,
     );
   });
@@ -42,32 +42,32 @@ describe('vueComponentProp().optional', () => {
 
 describe('vueComponentProp().nullable', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<VueComponent | null>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<VueComponent | null>>().type.toBeAssignableWith(
       vueComponentProp().nullable,
     );
-    expect<Vue2_6.PropOptions<VueComponent>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<VueComponent>>().type.not.toBeAssignableWith(
       vueComponentProp().nullable,
     );
 
-    expect(createVue2Component(vueComponentProp().nullable)).type.toEqual<
+    expect(createVue2Component(vueComponentProp().nullable)).type.toBe<
       Vue2ComponentWithProp<VueComponent | null>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<VueComponent | null>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<VueComponent | null>>().type.toBeAssignableWith(
       vueComponentProp().nullable,
     );
-    expect<Vue2_7.PropOptions<VueComponent>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<VueComponent>>().type.not.toBeAssignableWith(
       vueComponentProp().nullable,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<VueComponent | null>>().type.toBeAssignable(
+    expect<Vue3.Prop<VueComponent | null>>().type.toBeAssignableWith(
       vueComponentProp().nullable,
     );
-    expect<Vue3.Prop<VueComponent>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<VueComponent>>().type.not.toBeAssignableWith(
       vueComponentProp().nullable,
     );
   });
@@ -75,32 +75,32 @@ describe('vueComponentProp().nullable', () => {
 
 describe('vueComponentProp().withDefault', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<VueComponent>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<VueComponent>>().type.toBeAssignableWith(
       vueComponentProp().withDefault('foo'),
     );
-    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignableWith(
       vueComponentProp().withDefault('foo'),
     );
 
     expect(
       createVue2Component(vueComponentProp().withDefault('foo')),
-    ).type.toEqual<Vue2ComponentWithProp<VueComponent>>();
+    ).type.toBe<Vue2ComponentWithProp<VueComponent>>();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<VueComponent>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<VueComponent>>().type.toBeAssignableWith(
       vueComponentProp().withDefault('foo'),
     );
-    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignableWith(
       vueComponentProp().withDefault('foo'),
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<VueComponent>>().type.toBeAssignable(
+    expect<Vue3.Prop<VueComponent>>().type.toBeAssignableWith(
       vueComponentProp().withDefault('foo'),
     );
-    expect<Vue3.Prop<string>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<string>>().type.not.toBeAssignableWith(
       vueComponentProp().withDefault('foo'),
     );
   });
@@ -108,32 +108,32 @@ describe('vueComponentProp().withDefault', () => {
 
 describe('vueComponentProp().required', () => {
   test('Vue 2.6', () => {
-    expect<Vue2_6.PropOptions<VueComponent>>().type.toBeAssignable(
+    expect<Vue2_6.PropOptions<VueComponent>>().type.toBeAssignableWith(
       vueComponentProp().required,
     );
-    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_6.PropOptions<string>>().type.not.toBeAssignableWith(
       vueComponentProp().required,
     );
 
-    expect(createVue2Component(vueComponentProp().required)).type.toEqual<
+    expect(createVue2Component(vueComponentProp().required)).type.toBe<
       Vue2ComponentWithProp<VueComponent>
     >();
   });
 
   test('Vue 2.7', () => {
-    expect<Vue2_7.PropOptions<VueComponent>>().type.toBeAssignable(
+    expect<Vue2_7.PropOptions<VueComponent>>().type.toBeAssignableWith(
       vueComponentProp().required,
     );
-    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignable(
+    expect<Vue2_7.PropOptions<string>>().type.not.toBeAssignableWith(
       vueComponentProp().required,
     );
   });
 
   test('Vue 3', () => {
-    expect<Vue3.Prop<VueComponent>>().type.toBeAssignable(
+    expect<Vue3.Prop<VueComponent>>().type.toBeAssignableWith(
       vueComponentProp().required,
     );
-    expect<Vue3.Prop<string>>().type.not.toBeAssignable(
+    expect<Vue3.Prop<string>>().type.not.toBeAssignableWith(
       vueComponentProp().required,
     );
   });

--- a/type-tests/types.type.spec.ts
+++ b/type-tests/types.type.spec.ts
@@ -4,21 +4,21 @@ import type { Constructor, OneOfDefaultType } from '../src/types';
 declare class User {}
 declare const user1: User;
 
-expect<Constructor>().type.toBeAssignable(User);
-expect<Constructor>().type.toBeAssignable(Array);
-expect<Constructor>().type.toBeAssignable(Object);
-expect<Constructor>().type.not.toBeAssignable(undefined);
-expect<Constructor>().type.not.toBeAssignable({});
+expect<Constructor>().type.toBeAssignableWith(User);
+expect<Constructor>().type.toBeAssignableWith(Array);
+expect<Constructor>().type.toBeAssignableWith(Object);
+expect<Constructor>().type.not.toBeAssignableWith(undefined);
+expect<Constructor>().type.not.toBeAssignableWith({});
 
-expect<OneOfDefaultType<boolean>>().type.toBeAssignable(true);
-expect<OneOfDefaultType<boolean>>().type.not.toBeAssignable(undefined);
-expect<OneOfDefaultType<boolean>>().type.not.toBeAssignable(() => true);
+expect<OneOfDefaultType<boolean>>().type.toBeAssignableWith(true);
+expect<OneOfDefaultType<boolean>>().type.not.toBeAssignableWith(undefined);
+expect<OneOfDefaultType<boolean>>().type.not.toBeAssignableWith(() => true);
 
-expect<OneOfDefaultType<User>>().type.not.toBeAssignable(user1);
-expect<OneOfDefaultType<User>>().type.toBeAssignable(() => user1);
+expect<OneOfDefaultType<User>>().type.not.toBeAssignableWith(user1);
+expect<OneOfDefaultType<User>>().type.toBeAssignableWith(() => user1);
 
-expect<OneOfDefaultType<object>>().type.not.toBeAssignable({});
-expect<OneOfDefaultType<object>>().type.toBeAssignable(() => ({}));
+expect<OneOfDefaultType<object>>().type.not.toBeAssignableWith({});
+expect<OneOfDefaultType<object>>().type.toBeAssignableWith(() => ({}));
 
-expect<OneOfDefaultType<unknown[]>>().type.not.toBeAssignable([]);
-expect<OneOfDefaultType<unknown[]>>().type.toBeAssignable(() => []);
+expect<OneOfDefaultType<unknown[]>>().type.not.toBeAssignableWith([]);
+expect<OneOfDefaultType<unknown[]>>().type.toBeAssignableWith(() => []);

--- a/type-tests/validators/isInstanceOf.type.spec.ts
+++ b/type-tests/validators/isInstanceOf.type.spec.ts
@@ -3,5 +3,5 @@ import { isInstanceOf } from '../../src/validators/isInstanceOf';
 
 declare class User {}
 
-expect(isInstanceOf(Array)(undefined)).type.toEqual<string | undefined>();
-expect(isInstanceOf(User)(undefined)).type.toEqual<string | undefined>();
+expect(isInstanceOf(Array)(undefined)).type.toBe<string | undefined>();
+expect(isInstanceOf(User)(undefined)).type.toBe<string | undefined>();

--- a/type-tests/validators/isInteger.type.spec.ts
+++ b/type-tests/validators/isInteger.type.spec.ts
@@ -1,4 +1,4 @@
 import { expect } from 'tstyche';
 import { isInteger } from '../../src/validators/isInteger';
 
-expect(isInteger(undefined)).type.toEqual<string | undefined>();
+expect(isInteger(undefined)).type.toBe<string | undefined>();

--- a/type-tests/validators/isNegative.type.spec.ts
+++ b/type-tests/validators/isNegative.type.spec.ts
@@ -1,4 +1,4 @@
 import { expect } from 'tstyche';
 import { isNegative } from '../../src/validators/isNegative';
 
-expect(isNegative(undefined)).type.toEqual<string | undefined>();
+expect(isNegative(undefined)).type.toBe<string | undefined>();

--- a/type-tests/validators/isNonNegative.type.spec.ts
+++ b/type-tests/validators/isNonNegative.type.spec.ts
@@ -1,4 +1,4 @@
 import { expect } from 'tstyche';
 import { isNonNegative } from '../../src/validators/isNonNegative';
 
-expect(isNonNegative(undefined)).type.toEqual<string | undefined>();
+expect(isNonNegative(undefined)).type.toBe<string | undefined>();

--- a/type-tests/validators/isNonPositive.type.spec.ts
+++ b/type-tests/validators/isNonPositive.type.spec.ts
@@ -1,4 +1,4 @@
 import { expect } from 'tstyche';
 import { isNonPositive } from '../../src/validators/isNonPositive';
 
-expect(isNonPositive(undefined)).type.toEqual<string | undefined>();
+expect(isNonPositive(undefined)).type.toBe<string | undefined>();

--- a/type-tests/validators/isOneOf.type.spec.ts
+++ b/type-tests/validators/isOneOf.type.spec.ts
@@ -1,4 +1,4 @@
 import { expect } from 'tstyche';
 import { isOneOf } from '../../src/validators/isOneOf';
 
-expect(isOneOf([])(undefined)).type.toEqual<string | undefined>();
+expect(isOneOf([])(undefined)).type.toBe<string | undefined>();

--- a/type-tests/validators/isPositive.type.spec.ts
+++ b/type-tests/validators/isPositive.type.spec.ts
@@ -1,4 +1,4 @@
 import { expect } from 'tstyche';
 import { isPositive } from '../../src/validators/isPositive';
 
-expect(isPositive(undefined)).type.toEqual<string | undefined>();
+expect(isPositive(undefined)).type.toBe<string | undefined>();

--- a/type-tests/validators/isSymbol.type.spec.ts
+++ b/type-tests/validators/isSymbol.type.spec.ts
@@ -1,4 +1,4 @@
 import { expect } from 'tstyche';
 import { isSymbol } from '../../src/validators/isSymbol';
 
-expect(isSymbol(undefined)).type.toEqual<string | undefined>();
+expect(isSymbol(undefined)).type.toBe<string | undefined>();


### PR DESCRIPTION
TSTyche 2 is available as a release candidate, see: https://tstyche.org/releases/tstyche-2

There are two mayor improvements: matchers got better names and minimal `--watch` was added. At the moment it watches on the test files and TSTyche config file. That’s good for beginning. I made the changes you see in this PR while running TSTyche in the watch mode and that went quick and smooth.

@FloEdelmann You were interested to try out the watch mode (https://github.com/FloEdelmann/vue-ts-types/issues/506#issuecomment-1961045741). Give it a spin (;

The plan is to release stable version in a week or so. It is fine to wait and to land this PR later. Just wanted to drop you a note that `--watch` is already implemented.