### PR TITLE
Remove no longer needed VS Code setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "eslint.options": {
-    "overrideConfigFile": "eslint.config.mjs"
-  }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "eslint.experimental.useFlatConfig": true,
   "eslint.options": {
     "overrideConfigFile": "eslint.config.mjs"
   }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -126,7 +126,7 @@ export default typescriptEslint.config(
     },
   },
   {
-    files: ['eslint.config.mjs'],
+    files: ['eslint.config.js'],
     rules: {
       // less strict rules for ESLint config while some ESLint plugins don't provide proper types
       '@typescript-eslint/no-unsafe-argument': 'off',

--- a/lefthook.json
+++ b/lefthook.json
@@ -12,7 +12,7 @@
         "fail_text": "Please fix the formatting issues before committing. Use `npm run format`."
       },
       "eslint": {
-        "glob": "*.{mjs,ts}",
+        "glob": "*.{js,ts}",
         "run": "npx eslint {staged_files}",
         "fail_text": "Please fix the ESLint issues before committing. Try `npx eslint --fix .`."
       },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "license": "MIT",
   "author": "Flo Edelmann",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,5 @@
     "strict": true,
     "skipLibCheck": true
   },
-  "include": ["eslint.config.mjs", "**/*.ts"]
+  "include": ["eslint.config.js", "**/*.ts"]
 }


### PR DESCRIPTION
Following [microsoft/vscode-eslint#1644 (comment)](https://togithub.com/microsoft/vscode-eslint/issues/1644#issuecomment-2173587025), this PR removes the VS Code settings which are no longer necessary for ESLint linting.