### PR TITLE
Upgrade TSTyche

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "prettier": "3.3.3",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
-        "tstyche": "^2.1.1",
+        "tstyche": "^3.0.0-rc.2",
         "typescript": "^5.6.3",
         "typescript-eslint": "^8.12.2",
         "vue": "^3.5.12",
@@ -6579,16 +6579,16 @@
       }
     },
     "node_modules/tstyche": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tstyche/-/tstyche-2.1.1.tgz",
-      "integrity": "sha512-SvAukLfHk894rbBJEu6+7S9ZggN89FDe4VA0xT/mldW7gmqcpmNV7+OghlR2IZyUbkas4mjrjOKxSWZ3IQzV+w==",
+      "version": "3.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/tstyche/-/tstyche-3.0.0-rc.2.tgz",
+      "integrity": "sha512-sG7nX6igb9CoRGUku1mGS5LhwHgQd1zpXyAO8vF7Jt3atFRf0iAJ1+Od4cNqdw5GBCcIxi+g6CqG8sfFX2WCfQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "tstyche": "build/bin.js"
       },
       "engines": {
-        "node": ">=16.14"
+        "node": ">=18.19"
       },
       "funding": {
         "url": "https://github.com/tstyche/tstyche?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "prettier": "3.3.3",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
-    "tstyche": "^2.1.1",
+    "tstyche": "^3.0.0-rc.2",
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.12.2",
     "vue": "^3.5.12",


### PR DESCRIPTION
TSTyche 3.0 is coming out later this week. Release notes can be found [here](https://tstyche.org/releases/tstyche-3).

I decided to drop support for Node.js 16. It is old enough (;

But seems like this is now an issue for `vue-ts-types`. Do you plan to update the test matrix (by the way, the LTS release (v22) is missing)?

https://github.com/FloEdelmann/vue-ts-types/blob/253db50a803a2ee59c53b88d240913d295825aba/.github/workflows/test.yaml#L23

https://github.com/FloEdelmann/vue-ts-types/blob/253db50a803a2ee59c53b88d240913d295825aba/.github/workflows/test.yaml#L43

