### PR TITLE
Switch back to CommonJS

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,7 +33,7 @@ export default typescriptEslint.config(
   },
   eslintConfigPackageJson,
   {
-    files: ['**/*.ts', '**/*.js'],
+    files: ['**/*.ts', '**/*.mjs'],
     extends: [
       namedRecommendedEslintConfig,
       ...typescriptEslintStrictAndStylisticConfigs,
@@ -43,12 +43,12 @@ export default typescriptEslint.config(
   },
   {
     name: 'vue-ts-types/main',
-    files: ['**/*.ts', '**/*.js'],
+    files: ['**/*.ts', '**/*.mjs'],
     languageOptions: {
       ecmaVersion: 'latest',
       parserOptions: {
         projectService: {
-          allowDefaultProject: ['eslint.config.js'],
+          allowDefaultProject: ['eslint.config.mjs'],
           defaultProject: './tsconfig.json',
         },
       },
@@ -124,7 +124,7 @@ export default typescriptEslint.config(
   },
   {
     name: 'vue-ts-types/eslint',
-    files: ['eslint.config.js'],
+    files: ['eslint.config.mjs'],
     rules: {
       // less strict rules for ESLint config while some ESLint plugins don't provide proper types
       '@typescript-eslint/no-unsafe-argument': 'off',

--- a/lefthook.json
+++ b/lefthook.json
@@ -12,7 +12,7 @@
         "fail_text": "Please fix the formatting issues before committing. Use `npm run format`."
       },
       "eslint": {
-        "glob": "*.{js,ts}",
+        "glob": "*.{mjs,ts}",
         "run": "npx eslint {staged_files}",
         "fail_text": "Please fix the ESLint issues before committing. Try `npx eslint --fix .`."
       },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "license": "MIT",
   "author": "Flo Edelmann",
-  "type": "module",
+  "type": "commonjs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
Fixes #706.

I had added `"type": "module"` to `package.json` in #589, not thinking about that it has consequences for downstream consumers of the library. This PR changes it back to the [default value `"commonjs"`](https://nodejs.org/api/packages.html#type).