### PR TITLE
Use `@template` in JSDoc to document type parameters

### DIFF
--- a/src/prop-types/any.ts
+++ b/src/prop-types/any.ts
@@ -5,8 +5,7 @@ import type { Validator } from '../validators';
 /**
  * Allows any type. No built-in runtime validation is performed by default.
  *
- * Type parameter `T` can be used to restrict the type at compile time.
- *
+ * @template T - can be used to restrict the type at compile time.
  * @param validator - Optional function for runtime validation; should return `undefined` if valid, or an error string if invalid.
  */
 export const anyProp = <T = any>(

--- a/src/prop-types/array.ts
+++ b/src/prop-types/array.ts
@@ -5,8 +5,7 @@ import type { Validator } from '../validators';
 /**
  * Allows any array. No further runtime validation is performed by default.
  *
- * Type parameter `T` can be used to restrict the type of the array items at compile time.
- *
+ * @template T - can be used to restrict the type of the array items at compile time.
  *  @param validator - Optional function for further runtime validation; should return `undefined` if valid, or an error string if invalid.
  */
 export const arrayProp = <T = unknown>(

--- a/src/prop-types/function.ts
+++ b/src/prop-types/function.ts
@@ -13,8 +13,7 @@ interface FunctionPropOptionsGenerator<T> {
 /**
  * Allows any function. No further runtime validation is performed by default.
  *
- * Type parameter `T` can be used to restrict the type to a specific function signature at compile time.
- *
+ * @template T - can be used to restrict the type to a specific function signature at compile time.
  * @param validator - Optional function for further runtime validation; should return `undefined` if valid, or an error string if invalid.
  */
 export const functionProp = <T extends Function>(

--- a/src/prop-types/instanceOf.ts
+++ b/src/prop-types/instanceOf.ts
@@ -6,8 +6,7 @@ import { isInstanceOf } from '../validators';
 /**
  * Allows instances of the given constructor (validated at runtime and compile time).
  *
- * Type parameter `T` can be used to adjust the inferred type at compile time.
- *
+ * @template T - can be used to adjust the inferred type at compile time.
  * @param parent - The constructor to allow.
  * @param validator - Optional function for further runtime validation; should return `undefined` if valid, or an error string if invalid.
  */

--- a/src/prop-types/number.ts
+++ b/src/prop-types/number.ts
@@ -5,8 +5,7 @@ import type { Validator } from '../validators';
 /**
  * Allows any number (validated at runtime and compile time).
  *
- * Type parameter `T` can be used to restrict the type at compile time with a union type.
- *
+ * @template T - can be used to restrict the type at compile time with a union type.
  * @param validator - Optional function for further runtime validation; should return `undefined` if valid, or an error string if invalid.
  */
 export const numberProp = <T extends number = number>(

--- a/src/prop-types/object.ts
+++ b/src/prop-types/object.ts
@@ -5,8 +5,7 @@ import type { Validator } from '../validators';
 /**
  * Allows any object. No further runtime validation is performed by default.
  *
- * Type parameter `T` can be used to restrict the type at compile time.
- *
+ * @template T - can be used to restrict the type at compile time.
  * @param validator - Optional function for further runtime validation; should return `undefined` if valid, or an error string if invalid.
  */
 export const objectProp = <T = object>(

--- a/src/prop-types/oneOf.ts
+++ b/src/prop-types/oneOf.ts
@@ -35,8 +35,7 @@ const getOneOfType = <T extends readonly unknown[]>(
 /**
  * Allows any of the specified allowed values (validated at runtime and compile time).
  *
- * Type parameter `T` can be used to adjust the inferred type at compile time, this is usually not necessary.
- *
+ * @template T - can be used to adjust the inferred type at compile time, this is usually not necessary.
  * @param allowedValues - The allowed values.
  * @param validator - Optional function for further runtime validation; should return `undefined` if valid, or an error string if invalid.
  */

--- a/src/prop-types/oneOfObjectKeys.ts
+++ b/src/prop-types/oneOfObjectKeys.ts
@@ -7,8 +7,7 @@ type PlainObject = Record<number | string | symbol, unknown>;
 /**
  * Allows any of the keys of the specified object (validated at runtime and compile time).
  *
- * Type parameter `T` can be used to adjust the inferred type at compile time, this is usually not necessary.
- *
+ * @template T - can be used to adjust the inferred type at compile time, this is usually not necessary.
  * @param object - The object whose keys are allowed.
  * @param validator - Optional function for further runtime validation; should return `undefined` if valid, or an error string if invalid.
  */

--- a/src/prop-types/oneOfTypes.ts
+++ b/src/prop-types/oneOfTypes.ts
@@ -5,8 +5,7 @@ import type { Validator } from '../validators';
 /**
  * Allows any of the passed constructor types (validated at runtime).
  *
- * Type parameter `T` has to be used to adjust the type at compile time.
- *
+ * @template T - has to be used to adjust the type at compile time.
  * @param type - A single constructor or an array of constructors to allow.
  * @param validator - Optional function for further runtime validation; should return `undefined` if valid, or an error string if invalid.
  */

--- a/src/prop-types/string.ts
+++ b/src/prop-types/string.ts
@@ -5,8 +5,7 @@ import type { Validator } from '../validators';
 /**
  * Allows any string. No further runtime validation is performed by default.
  *
- * Type parameter `T` can be used to restrict the type at compile time with a union type.
- *
+ * @template T - can be used to restrict the type at compile time with a union type.
  * @param validator - Optional function for further runtime validation; should return `undefined` if valid, or an error string if invalid.
  */
 export const stringProp = <T extends string = string>(


### PR DESCRIPTION
See https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#template. It is not documented in https://jsdoc.app/ though.