### PR TITLE
Convert ESLint config to TypeScript

### DIFF
--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -1,5 +1,3 @@
-// @ts-check
-
 import eslintJs from '@eslint/js';
 import eslintConfigPackageJson from 'eslint-plugin-package-json/configs/recommended';
 import eslintConfigPrettier from 'eslint-config-prettier';

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,13 @@
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.18.0",
+        "@types/eslint-config-prettier": "^6.11.3",
         "@vitest/eslint-plugin": "^1.1.25",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
         "eslint-plugin-package-json": "^0.19.0",
         "eslint-plugin-unicorn": "^56.0.1",
+        "jiti": "^2.4.2",
         "lefthook": "^1.10.4",
         "markdownlint-cli": "^0.43.0",
         "prettier": "3.4.2",
@@ -1167,6 +1169,13 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@types/eslint-config-prettier": {
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/@types/eslint-config-prettier/-/eslint-config-prettier-6.11.3.tgz",
+      "integrity": "sha512-3wXCiM8croUnhg9LdtZUJQwNcQYGWxxdOWDjPe1ykCqJFPVpzAKfs/2dgSoCtAvdPeaponcWPI7mPcGGp9dkKQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.6",
@@ -2831,6 +2840,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -46,11 +46,13 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",
+    "@types/eslint-config-prettier": "^6.11.3",
     "@vitest/eslint-plugin": "^1.1.25",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-package-json": "^0.19.0",
     "eslint-plugin-unicorn": "^56.0.1",
+    "jiti": "^2.4.2",
     "lefthook": "^1.10.4",
     "markdownlint-cli": "^0.43.0",
     "prettier": "3.4.2",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,5 +3,12 @@
   "compilerOptions": {
     "rootDir": "./src"
   },
-  "exclude": ["vitest.config.ts", "tests", "type-tests", "node_modules", "dist"]
+  "exclude": [
+    "eslint.config.mts",
+    "vitest.config.ts",
+    "tests",
+    "type-tests",
+    "node_modules",
+    "dist"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "es2019",
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "declaration": true,
     "outDir": "./dist/",
     "esModuleInterop": true,
@@ -10,5 +10,5 @@
     "strict": true,
     "skipLibCheck": true
   },
-  "include": ["**/*.ts"]
+  "include": ["**/*.ts", "eslint.config.mts"]
 }

--- a/type-tests/prop-types/any.type.spec.ts
+++ b/type-tests/prop-types/any.type.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'tstyche';
 import type * as Vue2_6 from 'vue2-6/types/options';
 import type * as Vue2_7 from 'vue2-7/types/options';
-import type * as Vue3 from '@vue/runtime-core/dist/runtime-core';
+import type * as Vue3 from '@vue/runtime-core';
 import { anyProp } from '../../src/prop-types/any';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';

--- a/type-tests/prop-types/array.type.spec.ts
+++ b/type-tests/prop-types/array.type.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'tstyche';
 import type * as Vue2_6 from 'vue2-6/types/options';
 import type * as Vue2_7 from 'vue2-7/types/options';
-import type * as Vue3 from '@vue/runtime-core/dist/runtime-core';
+import type * as Vue3 from '@vue/runtime-core';
 import { arrayProp } from '../../src/prop-types/array';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';

--- a/type-tests/prop-types/boolean.type.spec.ts
+++ b/type-tests/prop-types/boolean.type.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'tstyche';
 import type * as Vue2_6 from 'vue2-6/types/options';
 import type * as Vue2_7 from 'vue2-7/types/options';
-import type * as Vue3 from '@vue/runtime-core/dist/runtime-core';
+import type * as Vue3 from '@vue/runtime-core';
 import { booleanProp } from '../../src/prop-types/boolean';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';

--- a/type-tests/prop-types/date.type.spec.ts
+++ b/type-tests/prop-types/date.type.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'tstyche';
 import type * as Vue2_6 from 'vue2-6/types/options';
 import type * as Vue2_7 from 'vue2-7/types/options';
-import type * as Vue3 from '@vue/runtime-core/dist/runtime-core';
+import type * as Vue3 from '@vue/runtime-core';
 import { dateProp } from '../../src/prop-types/date';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';

--- a/type-tests/prop-types/function.type.spec.ts
+++ b/type-tests/prop-types/function.type.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'tstyche';
 import type * as Vue2_6 from 'vue2-6/types/options';
 import type * as Vue2_7 from 'vue2-7/types/options';
-import type * as Vue3 from '@vue/runtime-core/dist/runtime-core';
+import type * as Vue3 from '@vue/runtime-core';
 import { functionProp } from '../../src/prop-types/function';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';

--- a/type-tests/prop-types/instanceOf.type.spec.ts
+++ b/type-tests/prop-types/instanceOf.type.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'tstyche';
 import type * as Vue2_6 from 'vue2-6/types/options';
 import type * as Vue2_7 from 'vue2-7/types/options';
-import type * as Vue3 from '@vue/runtime-core/dist/runtime-core';
+import type * as Vue3 from '@vue/runtime-core';
 import { instanceOfProp } from '../../src/prop-types/instanceOf';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';

--- a/type-tests/prop-types/integer.type.spec.ts
+++ b/type-tests/prop-types/integer.type.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'tstyche';
 import type * as Vue2_6 from 'vue2-6/types/options';
 import type * as Vue2_7 from 'vue2-7/types/options';
-import type * as Vue3 from '@vue/runtime-core/dist/runtime-core';
+import type * as Vue3 from '@vue/runtime-core';
 import { integerProp } from '../../src/prop-types/integer';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';

--- a/type-tests/prop-types/number.type.spec.ts
+++ b/type-tests/prop-types/number.type.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'tstyche';
 import type * as Vue2_6 from 'vue2-6/types/options';
 import type * as Vue2_7 from 'vue2-7/types/options';
-import type * as Vue3 from '@vue/runtime-core/dist/runtime-core';
+import type * as Vue3 from '@vue/runtime-core';
 import { numberProp } from '../../src/prop-types/number';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';

--- a/type-tests/prop-types/object.type.spec.ts
+++ b/type-tests/prop-types/object.type.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'tstyche';
 import type * as Vue2_6 from 'vue2-6/types/options';
 import type * as Vue2_7 from 'vue2-7/types/options';
-import type * as Vue3 from '@vue/runtime-core/dist/runtime-core';
+import type * as Vue3 from '@vue/runtime-core';
 import { objectProp } from '../../src/prop-types/object';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';

--- a/type-tests/prop-types/oneOf.type.spec.ts
+++ b/type-tests/prop-types/oneOf.type.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'tstyche';
 import type * as Vue2_6 from 'vue2-6/types/options';
 import type * as Vue2_7 from 'vue2-7/types/options';
-import type * as Vue3 from '@vue/runtime-core/dist/runtime-core';
+import type * as Vue3 from '@vue/runtime-core';
 import { oneOfProp } from '../../src/prop-types/oneOf';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';

--- a/type-tests/prop-types/oneOfObjectKeys.type.spec.ts
+++ b/type-tests/prop-types/oneOfObjectKeys.type.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'tstyche';
 import type * as Vue2_6 from 'vue2-6/types/options';
 import type * as Vue2_7 from 'vue2-7/types/options';
-import type * as Vue3 from '@vue/runtime-core/dist/runtime-core';
+import type * as Vue3 from '@vue/runtime-core';
 import { oneOfObjectKeysProp } from '../../src/prop-types/oneOfObjectKeys';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';

--- a/type-tests/prop-types/oneOfTypes.type.spec.ts
+++ b/type-tests/prop-types/oneOfTypes.type.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'tstyche';
 import type * as Vue2_6 from 'vue2-6/types/options';
 import type * as Vue2_7 from 'vue2-7/types/options';
-import type * as Vue3 from '@vue/runtime-core/dist/runtime-core';
+import type * as Vue3 from '@vue/runtime-core';
 import { oneOfTypesProp } from '../../src/prop-types/oneOfTypes';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';

--- a/type-tests/prop-types/string.type.spec.ts
+++ b/type-tests/prop-types/string.type.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'tstyche';
 import type * as Vue2_6 from 'vue2-6/types/options';
 import type * as Vue2_7 from 'vue2-7/types/options';
-import type * as Vue3 from '@vue/runtime-core/dist/runtime-core';
+import type * as Vue3 from '@vue/runtime-core';
 import { stringProp } from '../../src/prop-types/string';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';

--- a/type-tests/prop-types/symbol.type.spec.ts
+++ b/type-tests/prop-types/symbol.type.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'tstyche';
 import type * as Vue2_6 from 'vue2-6/types/options';
 import type * as Vue2_7 from 'vue2-7/types/options';
-import type * as Vue3 from '@vue/runtime-core/dist/runtime-core';
+import type * as Vue3 from '@vue/runtime-core';
 import { symbolProp } from '../../src/prop-types/symbol';
 import { createVue2Component } from '../utils';
 import type { Vue2ComponentWithProp } from '../utils';

--- a/type-tests/prop-types/vueComponent.type.spec.ts
+++ b/type-tests/prop-types/vueComponent.type.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'tstyche';
 import type * as Vue2_6 from 'vue2-6/types/options';
 import type * as Vue2_7 from 'vue2-7/types/options';
-import type * as Vue3 from '@vue/runtime-core/dist/runtime-core';
+import type * as Vue3 from '@vue/runtime-core';
 import { vueComponentProp } from '../../src/prop-types/vueComponent';
 import type { VueComponent } from '../../src/prop-types/vueComponent';
 import { createVue2Component } from '../utils';


### PR DESCRIPTION
Supported since https://github.com/eslint/eslint/releases/tag/v9.18.0, when `jiti` is installed.

The import from `eslint-plugin-package-json/configs/recommended` needs `"moduleResolution": "NodeNext"`, which in turn needs `"module": "NodeNext"`. I verified that the build output doesn't change with this config change.